### PR TITLE
fix: use rustls instead of native-tls for better portability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12", features = ["gzip", "brotli", "json", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "gzip", "brotli", "json", "stream"] }
 sha2 = "0.10"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
## Description

Switch reqwest from native-tls (which requires OpenSSL on Linux) to rustls for better cross-platform portability and easier CI/CD builds.

## Problem

The default `reqwest` configuration uses `native-tls` which requires OpenSSL to be installed on Linux systems. This creates additional system dependencies and can complicate CI/CD builds, especially in containerized environments.

## Solution

Configure `reqwest` to use `rustls-tls` instead of the default `native-tls`:
- Set `default-features = false` to disable native-tls
- Add `rustls-tls` feature flag explicitly
- Keep all existing features (gzip, brotli, json, stream)

## Benefits

- ✅ No OpenSSL dependency required on Linux
- ✅ Pure Rust TLS implementation
- ✅ Better cross-platform portability
- ✅ Easier containerization and CI/CD
- ✅ Maintained security with rustls

## Testing

- Built successfully with `cargo build --release`
- All tests pass: `cargo test --workspace`
- HTTP fetching tested: Successfully fetched and indexed a test source
- No performance regression observed

## Related Issues

This addresses potential build issues in CI/CD environments where OpenSSL may not be available.

🤖 Generated with [Claude Code](https://claude.ai/code)