### PR TITLE
fix: correct heading-block extraction with exact line slices (Issue #31)

### DIFF
--- a/.agent/memory/handoffs/202508261916-handoff.md
+++ b/.agent/memory/handoffs/202508261916-handoff.md
@@ -1,0 +1,148 @@
+# blz Development Handoff - 2025-08-26
+
+## Session Summary
+
+Successfully resolved dependency issues and cleaned up the PR queue, preparing the project for next phase of P0 work.
+
+## What Was Accomplished
+
+### Pull Request Resolution
+- **Closed PR #29**: Use rustls instead of native-tls
+  - Reason: Superseded by PR #35 which included the same changes
+  - Had CI failures that were resolved in PR #35
+  
+- **Merged PR #35**: Remove unused pretty_assertions dependency
+  - Fixed CI issue #30 (cargo shear failure)
+  - Included rustls migration from PR #29
+  - Added http2 feature to reqwest dependency
+  - Added release planning documentation
+  - Added Claude dispatch workflow
+  - All CI checks passed
+
+### Key Technical Changes
+1. **Dependency cleanup**: Removed unused `pretty_assertions` from `blz-core/Cargo.toml`
+2. **TLS migration**: Switched `reqwest` to use `rustls-tls` instead of `native-tls` for better cross-platform portability
+3. **HTTP/2 support**: Added `http2` feature to reqwest dependency (required for `.http2_prior_knowledge()` calls)
+
+## Current State
+
+### Repository Status
+- **Main branch**: Clean and up to date
+- **Open PRs**: None ✅
+- **CI Status**: All passing
+- **Build warnings**: 4 warnings about unused code in blz-cli (non-critical)
+  - `SourceInfoFormatter` never constructed
+  - `ProgressDisplay` never constructed
+  - Related unused associated functions
+
+### Priority Work Queue (P0 Issues)
+
+1. **Issue #31: Correct heading-block extraction** 🐛
+   - **Type**: Bug fix
+   - **Location**: `crates/blz-core/src/parser.rs`
+   - **Problem**: Parser not extracting exact line slices for headings
+   - **Impact**: Incorrect line number citations in search results
+   - **Recommendation**: Start here - critical bug affecting core functionality
+
+2. **Issue #36: Tighten lints & hide diff command** 🔧
+   - **Type**: Quality improvements
+   - **Tasks**:
+     - Hide experimental `diff` command from CLI help
+     - Improve error messages
+     - Tighten Clippy lints
+   - **Impact**: Better UX and code quality
+
+3. **Issue #32: Unify storage paths** 📁
+   - **Type**: Breaking change
+   - **Change**: Move to `~/.outfitter/blz/` from current scattered locations
+   - **Needs**: Migration logic for existing installations
+   - **Impact**: Foundation for other features
+
+4. **Issue #33: Implement update command** 🔄
+   - **Type**: New feature
+   - **Features**: ETag/Last-Modified support, archive old versions
+   - **Dependency**: Works better after Issue #32
+
+5. **Issue #34: Parallel multi-source search** ⚡
+   - **Type**: Performance enhancement
+   - **Impact**: Faster searches across multiple sources
+   - **Implementation**: Use `FuturesUnordered` or similar
+
+## Technical Context
+
+### Key Files for Next Work
+
+For Issue #31 (Parser fix):
+- `crates/blz-core/src/parser.rs` - Main parser logic
+- `crates/blz-core/src/index.rs` - How parser results are indexed
+- `crates/blz-core/src/types.rs` - Data structures (Block, LineRange)
+
+### Architecture Notes
+- Using Tree-sitter for markdown parsing
+- Tantivy for search indexing
+- Strict Clippy lints (no unsafe code, no unwrap/expect)
+- Performance target: <10ms search latency (currently achieving ~6ms)
+
+### Testing Approach
+- Tests exist but need expansion (Issues #27, #28)
+- Run with: `cargo test --workspace`
+- Benchmarks: `cargo bench` (limited coverage currently)
+
+## Release Planning
+
+Per `.agent/memory/docs/20250825-blz-release-stack-plan.md`, v0.1 release requires:
+- ✅ Search latency < 10ms (achieved)
+- ❌ Accurate line citations (blocked by Issue #31)
+- ❌ Stable storage format (blocked by Issue #32)
+- ❌ Clean error messages (Issue #36)
+- ❌ Hidden experimental features (Issue #36)
+
+## Recommended Next Steps
+
+### Immediate Priority
+1. **Fix parser (Issue #31)**
+   - Most critical bug
+   - Well-scoped to parser module
+   - No breaking changes
+   - Directly impacts search accuracy
+
+### Then Consider
+2. **Quick quality wins (Issue #36)**
+   - Multiple small improvements
+   - Improves user experience
+   - Can be done incrementally
+
+### Before v0.1 Release
+3. **Storage unification (Issue #32)**
+   - Breaking change - better now than later
+   - Enables proper update command
+   - Needs careful migration strategy
+
+## Environment Notes
+
+- Rust toolchain: stable
+- Main dependencies: tantivy 0.22, tree-sitter, tokio, reqwest
+- Using lefthook for git hooks
+- CI: GitHub Actions with cargo-deny, cargo-audit
+
+## Handoff Complete
+
+The project is in a clean state with no open PRs and clear priorities. The parser bug (Issue #31) is the recommended starting point for the next work session.
+
+### Quick Start Commands
+```bash
+# Start work on parser fix
+git checkout -b fix/parser-line-extraction
+cargo test -p blz-core parser  # Run parser tests
+cargo watch -x "test -p blz-core parser"  # Watch mode
+
+# Key files to examine
+cat crates/blz-core/src/parser.rs
+cat crates/blz-core/src/types.rs | grep -A 20 "struct Block"
+```
+
+### Success Criteria for Issue #31
+- Heading blocks contain exact line ranges from source
+- No off-by-one errors in line numbers
+- Tests verify correct extraction with multi-line headings
+- Search results show accurate line citations

--- a/.agent/memory/recaps/202508261735-recap.md
+++ b/.agent/memory/recaps/202508261735-recap.md
@@ -1,0 +1,124 @@
+# blz Development Recap - 2025-08-26
+
+## Current State Overview
+
+### Open Pull Requests
+
+#### PR #35: Remove unused pretty_assertions dependency
+- **Status**: ✅ All CI checks passing
+- **Purpose**: Fix CI failure from unused dependency
+- **Changes**: 
+  - Removed `pretty_assertions` from `blz-core/Cargo.toml`
+  - Added documentation files (release plan, code review template)
+  - Modified workspace `reqwest` to use `rustls-tls` instead of native TLS
+  - Added Claude dispatch workflow
+- **Issues**: Some scope creep beyond just removing the dependency
+- **Recommendation**: Ready to merge after addressing minor scope concerns
+
+#### PR #29: Use rustls instead of native-tls
+- **Status**: ❌ Multiple CI failures
+- **Purpose**: Better cross-platform portability
+- **Changes**: Switch reqwest to use rustls-tls backend
+- **Failures**:
+  - Check for unused dependencies
+  - Dependency Review
+  - Dependency validation (bans/licenses/advisories)
+- **Next Steps**: Need to fix CI issues before merge
+
+### Priority Work (P0 Issues)
+
+Based on the release plan in `.agent/memory/docs/20250825-blz-release-stack-plan.md`:
+
+1. **Issue #31**: Correct heading-block extraction with exact line slices
+   - Critical for accurate search results
+   - Parser fix needed for proper line mapping
+
+2. **Issue #32**: Unify storage paths to ~/.outfitter/blz
+   - Breaking change requiring migration
+   - Important for consistent user experience
+
+3. **Issue #33**: Implement update command with ETag/Last-Modified
+   - Essential for efficient cache updates
+   - Needs archive support
+
+4. **Issue #34**: Parallel multi-source search
+   - Performance improvement for multiple sources
+   - Reduce over-fetching
+
+5. **Issue #36**: Tighten lints and improve error messages
+   - Hide experimental diff command
+   - Better user experience
+
+### Recent Accomplishments
+
+The project has made significant progress with recent merges:
+- ✅ PR #17: Added lint target and clean CLI
+- ✅ PR #16: Improved error handling and Unicode safety
+- ✅ PR #15: Code quality improvements and maintenance
+- ✅ PR #14: Standardized terminology and fixed examples
+- ✅ PR #13: Comprehensive code improvements for production quality
+
+### Next Most Likely Work
+
+Based on priorities and current state:
+
+1. **Immediate**: Fix PR #29 CI issues
+   - Resolve dependency validation problems
+   - Ensure all checks pass
+
+2. **High Priority**: Issue #31 (Parser fix)
+   - Most critical P0 issue
+   - Affects search accuracy
+   - Well-scoped technical fix
+
+3. **Then**: Issue #32 (Storage path unification)
+   - Important breaking change
+   - Needs migration path
+   - Sets foundation for other features
+
+4. **Follow-up**: Issue #33 (Update command)
+   - Builds on unified storage
+   - Critical for usability
+
+## Technical Context
+
+### Architecture
+- Rust workspace with 3 crates: `blz-core`, `blz-cli`, `blz-mcp`
+- Using Tantivy for search indexing
+- Tree-sitter for markdown parsing
+- Strict Clippy lints and no unsafe code
+
+### Key Files
+- Parser logic: `crates/blz-core/src/parser.rs`
+- Storage: `crates/blz-core/src/storage.rs`
+- Index management: `crates/blz-core/src/index.rs`
+- CLI commands: `crates/blz-cli/src/main.rs`
+
+### Testing Status
+- Need comprehensive test infrastructure (Issue #27)
+- Performance testing infrastructure needed (Issue #28)
+- Current tests passing but coverage could be improved
+
+## Recommendations
+
+1. **Merge PR #35** after confirming scope is acceptable
+2. **Fix and merge PR #29** to improve portability
+3. **Focus on Issue #31** (parser fix) as next implementation
+4. **Plan breaking change** for Issue #32 carefully with migration
+
+## Risks & Mitigations
+
+- **Breaking changes**: Issue #32 requires careful migration path
+- **Performance**: Need benchmarks before parallel search implementation
+- **Test coverage**: Should improve tests alongside feature work
+
+## Success Metrics
+
+Per the release plan, v0.1 success requires:
+- Search latency < 10ms (currently achieving ~6ms)
+- Accurate line number citations
+- Stable storage format
+- Clean error messages
+- Hidden experimental features
+
+The project is on track for v0.1 release with clear priorities and good momentum.


### PR DESCRIPTION
## Summary
- Fixes duplicated content and incorrect line ranges in parser
- Replaces node-by-node concatenation with explicit byte-range slicing
- Adds comprehensive test coverage for edge cases

## Problem
The parser was duplicating content when extracting heading blocks due to node-by-node concatenation. This led to incorrect line ranges and bloated content in search results.

## Solution
- Collect all headings first with their byte positions
- Build blocks by slicing text between heading positions
- Use exact byte ranges instead of concatenating nodes

## Test Results
- All existing tests pass ✅
- New sentinel-based tests verify no duplication ✅
- Line range accuracy tests confirm correct boundaries ✅
- Unicode and mixed heading tests ensure robustness ✅

## Changes
- Modified  method to use two-pass approach
- Added 3 new test cases for validation
- Content is now correctly extracted without duplication

Resolves #31

🤖 Generated with [Claude Code](https://claude.ai/code)