### PR TITLE
fix(#36): tighten lints, hide diff command, improve error messages

### DIFF
--- a/crates/blz-cli/src/cli.rs
+++ b/crates/blz-cli/src/cli.rs
@@ -254,7 +254,8 @@ pub enum Commands {
         alias: String,
     },
 
-    /// View diffs
+    /// View diffs (coming soon)
+    #[command(hide = true)]
     Diff {
         /// Source alias
         alias: String,

--- a/crates/blz-core/src/lib.rs
+++ b/crates/blz-core/src/lib.rs
@@ -1,16 +1,3 @@
-#![allow(missing_docs)]
-#![allow(clippy::cast_precision_loss)]
-#![allow(clippy::cast_possible_truncation)]
-#![allow(clippy::cast_possible_wrap)]
-#![allow(clippy::needless_pass_by_value)]
-#![allow(clippy::needless_pass_by_ref_mut)]
-#![allow(clippy::option_if_let_else)]
-#![allow(clippy::only_used_in_recursion)]
-#![allow(clippy::return_self_not_must_use)]
-#![allow(clippy::too_many_lines)]
-#![allow(clippy::unnecessary_wraps)]
-#![allow(clippy::unused_self)]
-
 //! # blz-core
 //!
 //! Core functionality for blz - a fast, local search cache for llms.txt documentation.


### PR DESCRIPTION
## Summary
- Removed broad lint allows from blz-core lib.rs 
- Hide diff command from CLI with `#[command(hide = true)]`
- Map HTTP 404 errors to clearer NotFound errors with suggestions

## Changes
- ✅ Removed broad  directives from crate level
- ✅ Scoped lint exceptions to specific functions only
- ✅ Hidden  command from CLI help
- ✅ Mapped HTTP 404 errors to  with helpful messages
- ✅ Fixed clippy warnings by refactoring methods to static functions
- ✅ Updated tests to expect NotFound error for 404 responses

## Testing
- All library tests pass
- Main binaries compile successfully
- Error messages provide actionable guidance

Closes #36