### PR TITLE
fix(#32): unify storage and config paths to ~/.outfitter/blz with migration

### DIFF
--- a/crates/blz-core/src/config.rs
+++ b/crates/blz-core/src/config.rs
@@ -5,7 +5,7 @@
 //!
 //! ## Configuration Hierarchy
 //!
-//! 1. **Global config**: `~/.config/outfitter/cache/global.toml`
+//! 1. **Global config**: Platform-specific config directory (see GlobalConfig docs)
 //! 2. **Per-source config**: `<source_dir>/settings.toml`
 //! 3. **Environment variables**: `CACHE_*` prefix
 //!
@@ -64,8 +64,8 @@ use std::path::{Path, PathBuf};
 /// ## File Location
 ///
 /// The configuration file is stored at:
-/// - Linux: `~/.config/outfitter/cache/global.toml`
-/// - macOS: `~/Library/Application Support/outfitter.cache/global.toml`  
+/// - Linux: `~/.config/outfitter/blz/global.toml`
+/// - macOS: `~/Library/Preferences/outfitter.blz/global.toml`  
 /// - Windows: `%APPDATA%\outfitter\cache\global.toml`
 ///
 /// ## Example Configuration File
@@ -163,8 +163,8 @@ pub struct PathsConfig {
     /// structure is: `root/<source_alias>/`
     ///
     /// Default locations:
-    /// - Linux: `~/.local/share/outfitter/cache`
-    /// - macOS: `~/Library/Application Support/outfitter.cache`
+    /// - Linux: `~/.local/share/outfitter/blz`
+    /// - macOS: `~/Library/Application Support/outfitter.blz`
     /// - Windows: `%APPDATA%\outfitter\cache`
     pub root: PathBuf,
 }
@@ -260,7 +260,7 @@ impl Config {
     ///
     /// Uses the system-appropriate config directory based on the platform:
     /// - Linux: `~/.config/outfitter/blz/global.toml`
-    /// - macOS: `~/Library/Application Support/outfitter.blz/global.toml`
+    /// - macOS: `~/Library/Preferences/outfitter.blz/global.toml`
     /// - Windows: `%APPDATA%\outfitter\blz\global.toml`
     ///
     /// # Errors
@@ -336,7 +336,12 @@ impl Default for Config {
             },
             paths: PathsConfig {
                 root: directories::ProjectDirs::from("dev", "outfitter", "blz").map_or_else(
-                    || PathBuf::from("~/.outfitter/blz"),
+                    || {
+                        // Expand home directory properly
+                        directories::BaseDirs::new()
+                            .map(|base| base.home_dir().join(".outfitter").join("blz"))
+                            .unwrap_or_else(|| PathBuf::from(".outfitter/blz"))
+                    },
                     |dirs| dirs.data_dir().to_path_buf(),
                 ),
             },

--- a/crates/blz-core/src/config.rs
+++ b/crates/blz-core/src/config.rs
@@ -259,19 +259,68 @@ impl Config {
     /// Get the path where the global configuration file is stored.
     ///
     /// Uses the system-appropriate config directory based on the platform:
-    /// - Linux: `~/.config/outfitter/cache/global.toml`
-    /// - macOS: `~/Library/Application Support/outfitter.cache/global.toml`
-    /// - Windows: `%APPDATA%\outfitter\cache\global.toml`
+    /// - Linux: `~/.config/outfitter/blz/global.toml`
+    /// - macOS: `~/Library/Application Support/outfitter.blz/global.toml`
+    /// - Windows: `%APPDATA%\outfitter\blz\global.toml`
     ///
     /// # Errors
     ///
     /// Returns an error if the system config directory cannot be determined,
     /// which may happen on unsupported platforms or in sandboxed environments.
     fn config_path() -> Result<PathBuf> {
-        let project_dirs = directories::ProjectDirs::from("dev", "outfitter", "cache")
+        let project_dirs = directories::ProjectDirs::from("dev", "outfitter", "blz")
             .ok_or_else(|| Error::Config("Failed to determine project directories".into()))?;
 
-        Ok(project_dirs.config_dir().join("global.toml"))
+        let config_path = project_dirs.config_dir().join("global.toml");
+
+        // Check for migration from old cache directory
+        Self::check_and_migrate_old_config(&config_path)?;
+
+        Ok(config_path)
+    }
+
+    /// Check if we need to migrate from the old cache config
+    fn check_and_migrate_old_config(new_config_path: &Path) -> Result<()> {
+        // Only migrate if new config doesn't exist
+        if new_config_path.exists() {
+            return Ok(());
+        }
+
+        // Try to find the old cache config
+        if let Some(old_project_dirs) = directories::ProjectDirs::from("dev", "outfitter", "cache")
+        {
+            let old_config_path = old_project_dirs.config_dir().join("global.toml");
+
+            if old_config_path.exists() {
+                // Create parent directory if needed
+                if let Some(parent) = new_config_path.parent() {
+                    std::fs::create_dir_all(parent).map_err(|e| {
+                        Error::Config(format!("Failed to create config directory: {e}"))
+                    })?;
+                }
+
+                // Attempt to copy the old config
+                match std::fs::copy(&old_config_path, new_config_path) {
+                    Ok(_) => {
+                        tracing::info!(
+                            "Migrated config from {} to {}",
+                            old_config_path.display(),
+                            new_config_path.display()
+                        );
+                    },
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to migrate config from {} to {}: {}",
+                            old_config_path.display(),
+                            new_config_path.display(),
+                            e
+                        );
+                    },
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -286,8 +335,8 @@ impl Default for Config {
                 allowlist: Vec::new(),
             },
             paths: PathsConfig {
-                root: directories::ProjectDirs::from("dev", "outfitter", "cache").map_or_else(
-                    || PathBuf::from("~/.outfitter/cache"),
+                root: directories::ProjectDirs::from("dev", "outfitter", "blz").map_or_else(
+                    || PathBuf::from("~/.outfitter/blz"),
                     |dirs| dirs.data_dir().to_path_buf(),
                 ),
             },

--- a/crates/blz-core/src/fetcher.rs
+++ b/crates/blz-core/src/fetcher.rs
@@ -14,7 +14,7 @@ impl Fetcher {
     pub fn new() -> Result<Self> {
         let client = Client::builder()
             .timeout(Duration::from_secs(30))
-            .user_agent("outfitter-blz/0.1.0")
+            .user_agent(concat!("outfitter-blz/", env!("CARGO_PKG_VERSION")))
             .gzip(true)
             .brotli(true)
             .build()

--- a/crates/blz-core/src/fetcher.rs
+++ b/crates/blz-core/src/fetcher.rs
@@ -14,7 +14,7 @@ impl Fetcher {
     pub fn new() -> Result<Self> {
         let client = Client::builder()
             .timeout(Duration::from_secs(30))
-            .user_agent("outfitter-cache/0.1.0")
+            .user_agent("outfitter-blz/0.1.0")
             .gzip(true)
             .brotli(true)
             .build()

--- a/crates/blz-core/src/storage.rs
+++ b/crates/blz-core/src/storage.rs
@@ -266,13 +266,20 @@ impl Storage {
                 // Check if there's actually content to migrate (look for llms.json files)
                 let has_content = fs::read_dir(old_root)
                     .map(|entries| {
-                        entries.filter_map(std::result::Result::ok).any(|entry| {
-                            let path = entry.path();
-                            path.is_dir() && path.join("llms.json").exists()
-                        })
+                        entries
+                            .filter_map(std::result::Result::ok)
+                            .any(|entry| {
+                                let path = entry.path();
+                                if !path.is_dir() {
+                                    return false;
+                                }
+                                let has_llms_json = path.join("llms.json").exists();
+                                let has_llms_txt = path.join("llms.txt").exists();
+                                let has_metadata = path.join("metadata.json").exists();
+                                has_llms_json || has_llms_txt || has_metadata
+                            })
                     })
                     .unwrap_or(false);
-
                 if has_content {
                     // Check if new directory already exists with content
                     if new_root.exists()

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -362,14 +362,16 @@ blz search "complex query" --flamegraph
 
 ```
 ~/.outfitter/blz/
-├── sources/          # Cached documentation
-│   ├── bun.json
-│   └── node.json
-├── indices/          # Search indices
-│   ├── bun.idx
-│   └── node.idx
-└── config.json      # Configuration
+├── <alias>/          # Per-source data
+│   ├── llms.txt     # Original documentation
+│   ├── llms.json    # Parsed structure
+│   ├── .index/      # Tantivy search index
+│   ├── .archive/    # Historical snapshots
+│   └── settings.toml # Source-specific config
+└── global.toml      # Global configuration
 ```
+
+Note: If upgrading from an earlier version, `blz` will automatically migrate your data from the old `~/.outfitter/cache/` directory.
 
 ## Tips
 


### PR DESCRIPTION
## Summary

- Changed storage path from  to
- Changed config path from  to
- Added automatic migration logic to detect and migrate existing data from old paths
- Updated user agent string from "outfitter-cache" to "outfitter-blz"
- Updated documentation to reflect new paths

## Migration Details

- Storage migration copies all source data directories if they exist
- Config migration copies global.toml if it exists
- Migration is non-destructive - old data is preserved
- Migration runs automatically on first use after upgrade

Fixes #32

## Test Plan

- [x] cargo test --workspace passes
- [x] Manual testing of migration logic
- [ ] Test on fresh install (no existing cache)
- [ ] Test with existing cache data to verify migration