### PR TITLE
feat: add draft branch support to skip pre-push hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -58,12 +58,14 @@ pre-push:
       run: make test
       skip:
         - wip
+        - draft
     
     # Build check (using Makefile)
     build:
       run: make build
       skip:
         - wip
+        - draft
 
 # Post-merge hook to remind about dependencies
 post-merge:

--- a/scripts/push-draft.sh
+++ b/scripts/push-draft.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Script to push draft branches without running hooks
+# Usage: ./scripts/push-draft.sh [branch-name]
+
+set -e
+
+BRANCH=${1:-$(git rev-parse --abbrev-ref HEAD)}
+
+echo "🚀 Pushing draft branch: $BRANCH (skipping hooks)"
+git push --no-verify origin "$BRANCH"
+
+echo "✅ Draft branch pushed successfully"
+echo "💡 Remember to run 'make ci' before marking PR ready for review"


### PR DESCRIPTION
# Skip pre-push hooks for draft PRs

- Add 'draft' skip condition to pre-push hooks
- Create push-draft.sh helper script for quick draft pushes
- Enable faster PR stack setup without waiting for builds/tests

This allows using 'draft:' in commit messages to skip hooks,
or using ./scripts/push-draft.sh for quick draft pushes.


Closes #51
