### PR TITLE
chore: add changesets for versioning and configure npm publishing workflows

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/.changeset/initial-release.md
+++ b/.changeset/initial-release.md
@@ -1,0 +1,45 @@
+---
+"@outfitter/blz": major
+---
+
+Initial v0.1.0 release of blz - Fast local search for llms.txt documentation
+
+### Core Features
+- Fast local search with millisecond latency (6ms typical)
+- Full-text search powered by Tantivy with BM25 ranking
+- Exact line citations for every search result
+- Support for multiple documentation sources with aliases
+- Offline-first design - works without internet connection
+- Tree-sitter based markdown parsing for accurate structure extraction
+- Archive support for historical documentation snapshots
+- Deterministic BM25 ranking (vectors optional, off by default)
+
+### CLI Commands
+- `add <alias> <url>` - Add and index a documentation source
+- `search <query> [--alias <ALIAS>]` - Search across indexed documentation
+- `lookup` - Line-accurate citations with exact file ranges
+- `get` - Retrieve specific content
+- `list` - List all indexed sources with metadata
+- `remove <alias>` - Remove a source and its index
+- `update [alias]` - Update sources with conditional fetching (ETag/Last-Modified)
+- `completions <shell>` - Generate shell completions (fish, bash, zsh, elvish, powershell)
+
+### Storage & Configuration
+- Unified storage path at `~/.outfitter/blz/` with automatic migration
+- Platform-specific data directories using OS conventions
+- Per-source data organization with metadata tracking
+- Global configuration at platform-specific config directories
+
+### Performance
+- Search latency: P50 < 10ms, 6ms typical for cached queries
+- Indexing speed: < 150ms per MB of markdown
+- Concurrent search across multiple sources (up to 8 concurrent)
+- Memory-efficient operation with streaming where possible
+- Smart pagination and result limiting to prevent over-fetching
+
+### Infrastructure
+- Robust error handling with graceful fallbacks
+- Comprehensive test coverage for edge cases
+- GitHub Actions CI/CD pipeline
+- Security auditing with cargo-deny
+- Detailed progress reporting for bulk operations

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,41 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Download release assets
+        uses: dsaltares/fetch-gh-release-asset@master
+        with:
+          version: ${{ github.event.release.tag_name }}
+          regex: true
+          file: "blz-.*"
+          target: "./npm/binaries/"
+
+      - name: Configure npm authentication
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+          echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
+
+      - name: Publish to npm with Bun
+        run: bun publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Run tests
+        run: cargo test --release
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Create Release Pull Request or Publish
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          publish: bun run release && cargo build --release
+          version: bun run version
+          commit: "chore: version packages"
+          title: "chore: version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Release Assets
+        if: steps.changesets.outputs.published == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.changesets.outputs.publishedPackages[0].version }}
+          files: |
+            target/release/blz
+            target/release/blz-mcp
+          generate_release_notes: true

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "outfitter-blaze",
+  "name": "@outfitter/blz",
   "version": "0.1.0",
   "description": "Fast local llms.txt search for agents",
   "keywords": [
@@ -39,8 +39,9 @@
     "LICENSE"
   ],
   "scripts": {
-    "postinstall": "node npm/postinstall.js",
-    "prepack": "node npm/prepack.js"
+    "changeset": "bunx @changesets/cli",
+    "version": "bunx @changesets/cli version",
+    "release": "bunx @changesets/cli publish"
   },
   "engines": {
     "node": ">=18.0.0"
@@ -57,5 +58,8 @@
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
+  },
+  "devDependencies": {
+    "@changesets/cli": "^2.27.1"
   }
 }


### PR DESCRIPTION
# Add Changesets for Release Management

This PR adds Changesets for versioning and release management, including:

- Configure Changesets with public access and patch-level dependency updates
- Create initial changeset for v0.1.0 release documenting all core features:
    - Fast local search with millisecond latency
    - Full-text search with BM25 ranking
    - Exact line citations for search results
    - Multiple documentation source support
    - Offline-first design
    - Tree-sitter markdown parsing
    - Archive support for historical documentation
- Add GitHub Actions workflows:
    - Release workflow for creating versioned releases
    - NPM publish workflow to publish packages on release
- Update package name to `@outfitter/blz` for npm scoped package
- Add Changesets CLI as a dev dependency
- Configure npm scripts for versioning and publishing

Closes #12