### PR TITLE
chore: mark unused progress and source info formatters for future use

### DIFF
--- a/crates/blz-cli/src/output/formatter.rs
+++ b/crates/blz-cli/src/output/formatter.rs
@@ -299,8 +299,12 @@ impl SearchResultFormatter {
 ///   }
 /// ]
 /// ```
+///
+/// Reserved for future use when implementing structured source info output.
+#[allow(dead_code)]
 pub struct SourceInfoFormatter;
 
+#[allow(dead_code)]
 impl SourceInfoFormatter {
     /// Format source information for display in the specified format
     ///

--- a/crates/blz-cli/src/output/progress.rs
+++ b/crates/blz-cli/src/output/progress.rs
@@ -2,10 +2,18 @@
 
 use indicatif::{ProgressBar, ProgressStyle};
 
+/// Progress display utilities for CLI operations
+///
+/// These methods are preserved for future use when implementing
+/// download progress, long-running operations, and batch processing.
+#[allow(dead_code)]
 pub struct ProgressDisplay;
 
+#[allow(dead_code)]
 impl ProgressDisplay {
     /// Create a new spinner with the given message
+    ///
+    /// Use for operations with unknown duration.
     pub fn spinner(message: &str) -> ProgressBar {
         let pb = ProgressBar::new_spinner();
         pb.set_style(
@@ -18,6 +26,8 @@ impl ProgressDisplay {
     }
 
     /// Create a progress bar for downloads or operations with known size
+    ///
+    /// Use for operations where progress can be measured.
     pub fn bar(total: u64) -> ProgressBar {
         let pb = ProgressBar::new(total);
         pb.set_style(


### PR DESCRIPTION
# Add `#[allow(dead_code)]` annotations to unused progress and formatter code

- Add `#[allow(dead_code)]` to ProgressDisplay struct and methods
- Add `#[allow(dead_code)]` to SourceInfoFormatter struct and methods
- Document these are preserved for future features
- Resolves compiler warnings about unused code

These utilities will be used when implementing:

- Download progress indicators
- Batch operation progress bars
- Structured source info output