### PR TITLE
feat: add progress-ui feature flag and clean up dead code

### DIFF
--- a/crates/blz-cli/Cargo.toml
+++ b/crates/blz-cli/Cargo.toml
@@ -10,7 +10,9 @@ build = "build.rs"
 workspace = true
 
 [features]
+progress-ui = []
 flamegraph = ["blz-core/flamegraph"]
+default = []
 
 [[bin]]
 name = "blz"

--- a/crates/blz-cli/src/output/formatter.rs
+++ b/crates/blz-cli/src/output/formatter.rs
@@ -301,10 +301,10 @@ impl SearchResultFormatter {
 /// ```
 ///
 /// Reserved for future use when implementing structured source info output.
-#[allow(dead_code)]
+#[cfg(feature = "progress-ui")]
 pub struct SourceInfoFormatter;
 
-#[allow(dead_code)]
+#[cfg(feature = "progress-ui")]
 impl SourceInfoFormatter {
     /// Format source information for display in the specified format
     ///

--- a/crates/blz-cli/src/output/progress.rs
+++ b/crates/blz-cli/src/output/progress.rs
@@ -6,10 +6,10 @@ use indicatif::{ProgressBar, ProgressStyle};
 ///
 /// These methods are preserved for future use when implementing
 /// download progress, long-running operations, and batch processing.
-#[allow(dead_code)]
+#[cfg(feature = "progress-ui")]
 pub struct ProgressDisplay;
 
-#[allow(dead_code)]
+#[cfg(feature = "progress-ui")]
 impl ProgressDisplay {
     /// Create a new spinner with the given message
     ///

--- a/crates/blz-core/src/fetcher.rs
+++ b/crates/blz-core/src/fetcher.rs
@@ -520,7 +520,6 @@ mod tests {
 
     // Temporarily disabled - mock server setup needs adjustment
     // #[tokio::test]
-    #[allow(dead_code)]
     async fn test_fetch_with_last_modified() -> anyhow::Result<()> {
         // Setup mock server
         let mock_server = MockServer::start().await;
@@ -678,7 +677,6 @@ mod tests {
 
     // Temporarily disabled - mock server setup needs adjustment
     // #[tokio::test]
-    #[allow(dead_code)]
     async fn test_fetch_with_both_etag_and_last_modified() -> anyhow::Result<()> {
         // Setup mock server
         let mock_server = MockServer::start().await;

--- a/crates/blz-core/src/index.rs
+++ b/crates/blz-core/src/index.rs
@@ -9,8 +9,6 @@ use tracing::{debug, info, Level};
 
 pub struct SearchIndex {
     index: Index,
-    #[allow(dead_code)]
-    schema: Schema,
     content_field: Field,
     path_field: Field,
     heading_path_field: Field,
@@ -57,7 +55,6 @@ impl SearchIndex {
 
         Ok(Self {
             index,
-            schema,
             content_field,
             path_field,
             heading_path_field,
@@ -106,7 +103,6 @@ impl SearchIndex {
 
         Ok(Self {
             index,
-            schema,
             content_field,
             path_field,
             heading_path_field,

--- a/crates/blz-core/src/integration_example.rs
+++ b/crates/blz-core/src/integration_example.rs
@@ -234,7 +234,7 @@ impl PerformanceStatsSummary {
 }
 
 /// Example usage function
-#[allow(dead_code)]
+#[cfg(test)]
 async fn example_usage() -> Result<()> {
     // Create high-performance search system
     let search_system = HighPerformanceSearchSystem::new(


### PR DESCRIPTION
# Remove all #[allow(dead_code)] attributes and properly handle unused code

- Feature-gate progress UI types (ProgressDisplay, SourceInfoFormatter) behind 'progress-ui' flag
- Remove unused schema field from SearchIndex struct
- Mark example function with #[cfg(test)] instead of #[allow(dead_code)]
- Remove #[allow(dead_code)] from commented-out test functions

This enforces zero-warnings bar without suppressing legitimate issues.

Closes #59