### PR TITLE
tests(blz-core): add trybuild compile-fail harness for API validation

### DIFF
--- a/crates/blz-core/Cargo.toml
+++ b/crates/blz-core/Cargo.toml
@@ -40,6 +40,7 @@ sysinfo.workspace = true
 
 [dev-dependencies]
 proptest = "1"
+trybuild = "1"
 criterion.workspace = true
 tempfile.workspace = true
 wiremock = "0.6"

--- a/crates/blz-core/tests/compile-fail/invalid_api.rs
+++ b/crates/blz-core/tests/compile-fail/invalid_api.rs
@@ -1,0 +1,9 @@
+//! Test case to verify compile-time API validation
+//! This test ensures that non-existent functions are caught at compile time
+
+fn main() {
+    // Intentionally references a non-existent symbol to force a compile error
+    // This validates that the API surface is properly exposed and typos are caught
+    let _ = blz_core::this_function_does_not_exist();
+}
+

--- a/crates/blz-core/tests/compile-fail/invalid_api.stderr
+++ b/crates/blz-core/tests/compile-fail/invalid_api.stderr
@@ -1,0 +1,5 @@
+error[E0425]: cannot find function `this_function_does_not_exist` in crate `blz_core`
+ --> tests/compile-fail/invalid_api.rs:3:23
+  |
+3 |     let _ = blz_core::this_function_does_not_exist();
+  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in `blz_core`

--- a/crates/blz-core/tests/ui.rs
+++ b/crates/blz-core/tests/ui.rs
@@ -1,0 +1,6 @@
+#[test]
+fn compile_fail_ui() {
+    let t = trybuild::TestCases::new();
+    // Add cases in a follow-up; running with no cases is OK
+    t.compile_fail("tests/compile-fail/*.rs");
+}


### PR DESCRIPTION
### TL;DR

Introduce trybuild compile-fail test harness in blz-core to catch API misuse at compile time.

### What changed?

- Added trybuild as a dev-dependency in blz-core's Cargo.toml
- Created a new test harness in `tests/ui.rs` that runs compile-fail tests
- Added a sample compile-fail test case in `tests/compile-fail/invalid_api.rs` that intentionally references a non-existent function
- Included the expected error output in `tests/compile-fail/invalid_api.stderr`

### How to test?

1. Run the tests in blz-core with `cargo test -p blz-core`
2. Verify that the compile-fail test passes (it should detect the intentional error)
3. Try adding a new compile-fail test case to validate additional API constraints

### Why make this change?

This change implements a compile-time API validation system that helps catch misuse of the blz-core API early in the development process. The trybuild harness ensures that certain code patterns that should fail compilation actually do fail with the expected error messages, providing an additional layer of API contract validation and preventing regressions in the public interface.


Closes #72
