### PR TITLE
docs: add DEPS.md and rust-patterns.md documentation

### DIFF
--- a/DEPS.md
+++ b/DEPS.md
@@ -1,0 +1,20 @@
+# Core Dependencies
+
+- tantivy: search engine powering indexing/search
+- tree-sitter + tree-sitter-md: markdown parsing with precise ranges
+- tokio: async runtime for I/O-bound tasks (features = ["full"])
+- reqwest: HTTP client (default-features = false; features = ["rustls-tls", "gzip", "brotli", "json", "stream", "http2"])
+- criterion: micro-benchmarking and regression tracking
+- pprof: CPU profiling and flamegraph generation (features = ["flamegraph", "protobuf-codec"])
+- sysinfo: lightweight process/machine metrics
+
+## Links
+- [Tantivy](https://github.com/quickwit-oss/tantivy)
+- [Tree-sitter](https://tree-sitter.github.io/)
+- [tree-sitter-markdown](https://github.com/MDeiml/tree-sitter-markdown)
+- [Tokio](https://tokio.rs/)
+- [Reqwest](https://docs.rs/reqwest/)
+- [Criterion](https://bheisler.github.io/criterion.rs/book/)
+- [pprof](https://docs.rs/pprof/)
+- [Sysinfo](https://docs.rs/sysinfo/)
+

--- a/docs/rust-patterns.md
+++ b/docs/rust-patterns.md
@@ -1,0 +1,52 @@
+# Rust Patterns
+
+## Async task spawning
+```rust
+pub fn spawn_worker<F, T>(fut: F) -> tokio::task::JoinHandle<anyhow::Result<T>>
+where
+    F: std::future::Future<Output = anyhow::Result<T>> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::spawn(async move { fut.await })
+}
+
+// Note: awaiting the handle returns Result<anyhow::Result<T>, tokio::task::JoinError>.
+// Handle both the join error (panic/cancellation) and the inner result:
+// let handle = spawn_worker(work());
+// let res = handle.await.context("worker join failed")?;
+// let out = res?;
+
+// For Tokio ≥1.37, you can name tasks for better debugging:
+// tokio::task::Builder::new().name("worker").spawn(async move { fut.await })
+```
+
+## Avoid borrows across `.await`
+- Clone `Arc`s and move owned data into the task
+- Extract smaller async steps/functions to shorten borrow lifetimes
+- Use `tokio::task::spawn_blocking` for blocking CPU/file work to avoid starving the runtime
+- Prefer timeouts and cancellation-aware loops (e.g. `tokio::select!`, `CancellationToken`)
+
+## Error context conventions
+- Use `anyhow::Context` when calling fallible operations
+- Prefer `thiserror` for typed error surfaces at crate boundaries
+
+Example:
+```rust
+use anyhow::Context as _;
+let data = std::fs::read(&path)
+    .with_context(|| format!("reading {}", path.display()))?;
+```
+
+## Macro debugging tips
+- Use `cargo expand` to inspect generated code
+- Add minimal repros to `tests/` with clear compile errors
+- Use `trybuild` compile-fail tests to lock diagnostics:
+```rust
+// tests/compile_fail.rs
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile-fail/*.rs");
+}
+```
+


### PR DESCRIPTION
# Add documentation for dependencies and Rust patterns

### TL;DR

Add documentation files for core dependencies and Rust coding patterns.

### What changed?

- Added `DEPS.md` to document core dependencies with links to their documentation
- Added `docs/rust-patterns.md` with best practices for:
  - Async task spawning with helper functions
  - Avoiding borrows across `.await` points
  - Error handling conventions with anyhow/thiserror
  - Macro debugging techniques

### How to test?

- Review the documentation for accuracy and completeness
- Verify links to external resources are correct
- Ensure the Rust code examples compile and follow project conventions

### Why make this change?

Improve developer onboarding and establish consistent patterns for common operations like async task management and error handling. This documentation helps standardize approaches to common Rust challenges across the codebase and provides guidance for contributors.


Closes #73
