### PR TITLE
ci(release): npm auto publish + auto release notes; fix HOMEBREW_TAP_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Upload release assets
         uses: softprops/action-gh-release@v2
         with:
+          generate_release_notes: true
           files: |
             dist/blz-darwin-arm64
             dist/blz-darwin-arm64.tar.gz
@@ -271,15 +272,64 @@ RUBY
           else
             echo "dev=false" >> $GITHUB_OUTPUT
           fi
+      - name: Extract version
+        if: steps.check.outputs.dev == 'false'
+        id: ver
+        shell: bash
+        run: |
+          VER=$(grep -m1 '^version\s*=\s*"' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+          echo "version=$VER" >> $GITHUB_OUTPUT
       - name: Publish (blz-core)
         if: steps.check.outputs.dev == 'false'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           cargo publish -p blz-core
+      - name: Wait for blz-core to propagate
+        if: steps.check.outputs.dev == 'false'
+        shell: bash
+        run: |
+          set -euo pipefail
+          V=${{ steps.ver.outputs.version }}
+          echo "Waiting for blz-core $V to appear on crates.io index..."
+          for i in {1..30}; do
+            if curl -fsSL https://crates.io/api/v1/crates/blz-core/versions | jq -r '.versions[].num' | grep -qx "$V"; then
+              echo "blz-core $V is available."
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Timed out waiting for blz-core $V to propagate" >&2
+          exit 1
       - name: Publish (blz-cli)
         if: steps.check.outputs.dev == 'false'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           cargo publish -p blz-cli
+
+  npm-publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: [build-darwin-arm64, build-darwin-x64, build-linux-x64, build-linux-arm64, build-windows-x64]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate package.json version matches tag
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(jq -r .version package.json)
+          if [ "$TAG" != "$PKG" ]; then
+            echo "Tag $TAG does not match package.json version $PKG" >&2
+            exit 1
+          fi
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@outfitter'
+      - name: npm publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ sysinfo = "0.32"
 tempfile = "3"
 url = "2"
 
-# Internal crates
-blz-core = { path = "crates/blz-core" }
+# Internal crates (ensure version is set for crates.io publish of dependents)
+blz-core = { path = "crates/blz-core", version = "0.1.2" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"


### PR DESCRIPTION
- Add npm publish job on tag (validates package.json version matches tag)
- Enable GitHub auto-generated release notes on first asset upload
- Use HOMEBREW_TAP_TOKEN for tap checkout and PR creation

Merging this enables fully automatic releases via tag.