### PR TITLE
ci(release): install jq for crates propagation check; ensure GH release creation isn't blocked by downstream failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build (release)
         run: |
@@ -57,11 +53,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build (release)
         run: |


### PR DESCRIPTION
ci(release): install jq for crates propagation check; ensure GH release creation isn't blocked by downstream failures

ci(release): use dtolnay/rust-toolchain for macOS jobs