### PR TITLE
fix(build): add ring workarounds for macOS ARM CPU feature detection issues

### DIFF
--- a/.github/workflows/release-cached.yml
+++ b/.github/workflows/release-cached.yml
@@ -129,6 +129,9 @@ jobs:
     name: Build macOS arm64
     runs-on: macos-14
     timeout-minutes: 45
+    env:
+      # Workaround for ring CPU feature detection issues on Apple Silicon
+      RING_DISABLE_ASM: 1
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,9 @@ jobs:
     name: Build macOS arm64
     runs-on: macos-14
     timeout-minutes: 45
+    env:
+      # Workaround for ring CPU feature detection issues on Apple Silicon
+      RING_DISABLE_ASM: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,13 @@ url = "2"
 # Internal crates (ensure version is set for crates.io publish of dependents)
 blz-core = { path = "crates/blz-core", version = "0.1.5" }
 
+[patch.crates-io]
+# Work around macOS ARM CPU feature detection panic in ring 0.17.14
+# Use upstream ring main until a new patch release is cut on crates.io
+ring = { git = "https://github.com/briansmith/ring", branch = "main" }
+
+
+
 [workspace.lints.rust]
 unsafe_code = "deny"
 missing_docs = "warn"

--- a/crates/blz-cli/Cargo.toml
+++ b/crates/blz-cli/Cargo.toml
@@ -10,7 +10,7 @@ build = "build.rs"
 workspace = true
 
 [features]
-flamegraph = ["blz-core/flamegraph"]
+flamegraph = ["dep:pprof", "blz-core/flamegraph"]
 
 [[bin]]
 name = "blz"
@@ -33,8 +33,8 @@ indicatif = "0.17"
 clap_complete = "4"
 dialoguer = "0.11"
 
-# Performance & profiling
-pprof.workspace = true
+# Performance & profiling (optional; enabled via feature "flamegraph")
+pprof = { workspace = true, optional = true }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/blz-core/Cargo.toml
+++ b/crates/blz-core/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 workspace = true
 
 [features]
-flamegraph = ["pprof/flamegraph"]
+flamegraph = ["dep:pprof", "pprof/flamegraph"]
 experimental_benches = []
 
 [dependencies]
@@ -36,7 +36,7 @@ tempfile = "3"
 futures = "0.3"
 
 # Performance & profiling
-pprof.workspace = true
+pprof = { workspace = true, optional = true }
 sysinfo.workspace = true
 
 [dev-dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -87,4 +87,5 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # Allow git dependencies from our own org (if needed)
 allow-git = [
     # "https://github.com/outfitter-dev/",
+    "https://github.com/briansmith/ring",
 ]


### PR DESCRIPTION
### TL;DR

Fix macOS ARM64 builds by working around CPU feature detection issues in the ring crate.

### What changed?

- Added `RING_DISABLE_ASM: 1` environment variable to macOS ARM64 build jobs in both release workflow files
- Patched the ring crate to use the latest version from GitHub main branch instead of crates.io
- Made the `pprof` dependency optional in both `blz-cli` and `blz-core` crates, only enabling it when the `flamegraph` feature is active
- Updated the deny.toml to allow the git dependency for ring

### How to test?

- Run the release workflows on macOS ARM64 runners
- Verify that the builds complete successfully without CPU feature detection panics
- Check that flamegraph functionality still works when the feature is enabled

### Why make this change?

The ring crate (v0.17.14) has CPU feature detection issues on Apple Silicon that cause panics during builds. This change implements two complementary workarounds:

1. Using the `RING_DISABLE_ASM` environment variable to disable assembly optimizations
2. Patching to the latest version from the ring repository which contains fixes not yet released to crates.io

Additionally, the PR makes pprof an optional dependency to reduce unnecessary dependencies when flamegraph features aren't being used.