### PR TITLE
feat(v0.3): re-enable anchor commands for future development

### DIFF
--- a/.agents/instructions/use-blz.md
+++ b/.agents/instructions/use-blz.md
@@ -33,7 +33,8 @@ blz "query invalidation" -s tanstack
 
 # Pagination
 blz "async" --limit 20 --page 2
-blz "async" --last  # jump to last page
+blz search --next  # next page of last search
+blz search --prev  # previous page
 
 # Output formats
 blz "routing" -o json   # JSON array

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ See [docs/performance.md](docs/performance.md) for detailed benchmarks and metho
 - **Smart Sync**: Conditional fetches with ETag/If-None-Match to minimize bandwidth
 - **Robust Parsing**: Handles imperfect `llms.txt` gracefully, always produces useful structure
 - **Deterministic Search**: BM25 ranking with Tantivy (vectors optional, off by default)
-- **Change Tracking**: Track source changes with `blz diff` command showing moved, added, and removed sections
+- **Change Tracking**: Coming in v0.2 – diff journal with unified diffs and changed sections
 - **Direct CLI Integration**: IDE agents run commands directly for instant results
 - **MCP Server** (coming soon): stdio-based integration via official Rust SDK
 

--- a/crates/blz-cli/src/cli.rs
+++ b/crates/blz-cli/src/cli.rs
@@ -227,30 +227,30 @@ pub enum Commands {
         format: crate::commands::DocsFormat,
     },
 
-    // Anchor commands disabled for v0.2 release - functionality needs more work
-    // /// Anchor utilities
-    // Anchor {
-    //     #[command(subcommand)]
-    //     command: AnchorCommands,
-    // },
+    /// Anchor utilities
+    Anchor {
+        #[command(subcommand)]
+        command: AnchorCommands,
+    },
 
-    // /// Show anchors for a source or remap mappings
-    // Anchors {
-    //     /// Source alias
-    //     alias: String,
-    //     /// Output format
-    //     #[arg(
-    //         short = 'o',
-    //         long,
-    //         value_enum,
-    //         default_value = "text",
-    //         env = "BLZ_OUTPUT_FORMAT"
-    //     )]
-    //     output: OutputFormat,
-    //     /// Show anchors remap mappings if available
-    //     #[arg(long)]
-    //     mappings: bool,
-    // },
+    /// Show anchors for a source or remap mappings
+    Anchors {
+        /// Source alias
+        alias: String,
+        /// Output format
+        #[arg(
+            short = 'o',
+            long,
+            value_enum,
+            default_value = "text",
+            env = "BLZ_OUTPUT_FORMAT"
+        )]
+        output: OutputFormat,
+        /// Show anchors remap mappings if available
+        #[arg(long)]
+        mappings: bool,
+    },
+
     /// Add a new source
     Add {
         /// Alias for the source

--- a/crates/blz-cli/src/commands/mod.rs
+++ b/crates/blz-cli/src/commands/mod.rs
@@ -18,9 +18,8 @@ mod update;
 
 pub use add::execute as add_source;
 pub use alias::{AliasCommand, execute as manage_alias};
-// Anchor commands disabled for v0.2
-// pub use anchors::execute as show_anchors;
-// pub use anchors::get_by_anchor;
+pub use anchors::execute as show_anchors;
+pub use anchors::get_by_anchor;
 pub use completions::generate;
 pub use completions::list_supported;
 pub use diff::show as show_diff;

--- a/crates/blz-cli/src/main.rs
+++ b/crates/blz-cli/src/main.rs
@@ -26,7 +26,7 @@ mod instruct_mod {
     }
 }
 
-use cli::{AliasCommands, /* AnchorCommands, */ Cli, Commands};
+use cli::{AliasCommands, AnchorCommands, Cli, Commands};
 
 #[cfg(feature = "flamegraph")]
 use blz_core::profiling::{start_profiling, stop_profiling_and_report};
@@ -79,8 +79,9 @@ fn initialize_logging(cli: &Cli) -> Result<()> {
     if !(cli.verbose || cli.debug) {
         // Suppress logs when emitting machine-readable output across common commands
         if let Some(
-            Commands::Search { output, .. } | Commands::List { output, .. },
-            // | Commands::Anchors { output, .. }, // Disabled for v0.2
+            Commands::Search { output, .. }
+            | Commands::List { output, .. }
+            | Commands::Anchors { output, .. },
         ) = &cli.command
         {
             if matches!(
@@ -155,14 +156,13 @@ async fn execute_command(cli: Cli, metrics: PerformanceMetrics) -> Result<()> {
             }
         },
         Some(Commands::Docs { format }) => handle_docs(format)?,
-        // Anchor commands disabled for v0.2 release
-        // Some(Commands::Anchor { command }) => handle_anchor(command).await?,
+        Some(Commands::Anchor { command }) => handle_anchor(command).await?,
         Some(Commands::Alias { command }) => handle_alias(command).await?,
-        // Some(Commands::Anchors {
-        //     alias,
-        //     output,
-        //     mappings,
-        // }) => commands::show_anchors(&alias, output, mappings).await?,
+        Some(Commands::Anchors {
+            alias,
+            output,
+            mappings,
+        }) => commands::show_anchors(&alias, output, mappings).await?,
         Some(Commands::Instruct) => instruct_mod::print(),
         Some(Commands::Add { alias, url, yes }) => {
             commands::add_source(&alias, &url, yes, metrics).await?;
@@ -222,22 +222,21 @@ fn handle_docs(format: crate::commands::DocsFormat) -> Result<()> {
     commands::generate_docs(effective)
 }
 
-// Anchor commands disabled for v0.2 release
-// async fn handle_anchor(command: AnchorCommands) -> Result<()> {
-//     match command {
-//         AnchorCommands::List {
-//             alias,
-//             output,
-//             mappings,
-//         } => commands::show_anchors(&alias, output, mappings).await,
-//         AnchorCommands::Get {
-//             alias,
-//             anchor,
-//             context,
-//             output,
-//         } => commands::get_by_anchor(&alias, &anchor, context, output).await,
-//     }
-// }
+async fn handle_anchor(command: AnchorCommands) -> Result<()> {
+    match command {
+        AnchorCommands::List {
+            alias,
+            output,
+            mappings,
+        } => commands::show_anchors(&alias, output, mappings).await,
+        AnchorCommands::Get {
+            alias,
+            anchor,
+            context,
+            output,
+        } => commands::get_by_anchor(&alias, &anchor, context, output).await,
+    }
+}
 
 async fn handle_alias(command: AliasCommands) -> Result<()> {
     match command {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -486,6 +486,9 @@ export BLZ_OUTPUT_FORMAT=json   # or text, ndjson
 # Now these default to JSON unless overridden
 blz search "async"
 blz list --status
+blz anchors react --mappings
+blz anchor list react -o json | jq '.[0]'
+blz anchor get react <ANCHOR> -o json | jq '.content'
 ```
 # `blz alias`
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -4,6 +4,7 @@ This section lists individual command reference pages. For the single‑page ref
 
 - [Search](./search.md)
 - [Get](./get.md)
+- [Anchors](./anchors.md)
 - [Lookup](./lookup.md)
 - [List](./list.md)
 - [Update](./update.md)

--- a/docs/commands/anchors.md
+++ b/docs/commands/anchors.md
@@ -1,0 +1,18 @@
+# Anchors
+
+Stable anchors and anchor-based retrieval.
+
+```bash
+blz anchors <SOURCE> [--mappings] [--output text|json|ndjson]
+blz anchor get <SOURCE> <ANCHOR> [--context N] [--output text|json|ndjson]
+```
+Examples
+
+```bash
+blz anchors react --mappings
+blz anchor list react -o json | jq '.[0]'
+blz anchor get react <ANCHOR> -o json | jq '.content'
+```
+
+See also:
+- [Output formats](./output-formats.md)


### PR DESCRIPTION
## Summary

This PR re-enables the anchor commands that were disabled for the v0.2 release. The anchor functionality needs more work before it's ready for production use.

## Context

The anchor commands (`blz anchor get`, `blz anchors`) were implemented in v0.2 but disabled because:
- The `anchor get` command doesn't work correctly (always returns "Anchor not found")
- Anchor IDs are not being generated properly (all show as `null`)
- The lookup/resolution system needs debugging

## What This PR Does

- Re-enables the anchor commands in the CLI
- Preserves all the anchor parsing and indexing infrastructure
- Keeps the work ready for completion in v0.3

## Next Steps for v0.3

1. Fix anchor ID generation
2. Debug the anchor lookup mechanism
3. Ensure anchor get command works with exact matches
4. Add comprehensive tests
5. Update documentation with working examples

## Note

This PR should NOT be merged into v0.2. It's stacked on top to preserve the work for v0.3 development.

🤖 Generated with [Claude Code](https://claude.ai/code)