### PR TITLE
ci(publish): unify publishing via reusable workflow (npm OIDC, crates.io, Homebrew, undraft)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,218 @@
+name: Publish
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g., v0.2.0)'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g., v0.2.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: "publish-${{ inputs.tag || github.event.inputs.tag }}"
+  cancel-in-progress: false
+
+jobs:
+  npm-publish:
+    name: "Publish: npm"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: "Checkout tag"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.event.inputs.tag }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@outfitter'
+
+      - name: Validate package.json version matches tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ inputs.tag || github.event.inputs.tag }}"
+          TAG_NO_V="${TAG#v}"
+          PKG=$(node -p "require('./package.json').version")
+          if [ "$TAG_NO_V" != "$PKG" ]; then
+            echo "Tag $TAG_NO_V does not match package.json version $PKG" >&2
+            exit 1
+          fi
+
+      - name: Check if npm version exists
+        id: npm_exists
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ inputs.tag || github.event.inputs.tag }}"
+          V="${TAG#v}"
+          if npm view @outfitter/blz@"$V" version >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: npm publish (OIDC provenance)
+        if: steps.npm_exists.outputs.exists != 'true'
+        run: npm publish --access public --provenance
+
+  cargo-publish:
+    name: "Publish: crates.io"
+    runs-on: ubuntu-latest
+    needs: npm-publish
+    steps:
+      - name: "Checkout tag"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.event.inputs.tag }}
+
+      - name: Validate Cargo.toml version matches tag
+        id: ver
+        shell: bash
+        run: |
+          TAG="${{ inputs.tag || github.event.inputs.tag }}"
+          TAG_NO_V="${TAG#v}"
+          VER=$(grep -m1 '^version\s*=\s*"' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+          echo "version=$VER" >> $GITHUB_OUTPUT
+          if [ "$TAG_NO_V" != "$VER" ]; then
+            echo "Tag ${TAG_NO_V} does not match Cargo.toml version ${VER}" >&2
+            exit 1
+          fi
+
+      - name: Check if blz-core exists
+        id: crate_core_exists
+        shell: bash
+        run: |
+          set -euo pipefail
+          V=${{ steps.ver.outputs.version }}
+          if curl --retry 3 --retry-delay 1 --fail --silent --show-error https://crates.io/api/v1/crates/blz-core/versions | jq -r '.versions[].num' | grep -qx "$V"; then
+            echo exists=true >> $GITHUB_OUTPUT
+          else
+            echo exists=false >> $GITHUB_OUTPUT
+          fi
+
+      - name: Publish blz-core
+        if: steps.crate_core_exists.outputs.exists != 'true'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p blz-core --locked
+
+      - name: Wait for blz-core to propagate
+        if: steps.crate_core_exists.outputs.exists != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          V=${{ steps.ver.outputs.version }}
+          echo "Waiting for blz-core $V to appear on crates.io..."
+          for i in {1..30}; do
+            if curl --retry 3 --retry-delay 1 -fsSL https://crates.io/api/v1/crates/blz-core/versions | jq -r '.versions[].num' | grep -qx "$V"; then
+              echo "blz-core $V is available."
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Timed out waiting for blz-core $V to propagate" >&2
+          exit 1
+
+      - name: Check if blz-cli exists
+        id: crate_cli_exists
+        shell: bash
+        run: |
+          set -euo pipefail
+          V=${{ steps.ver.outputs.version }}
+          if curl --retry 3 --retry-delay 1 --fail --silent --show-error https://crates.io/api/v1/crates/blz-cli/versions | jq -r '.versions[].num' | grep -qx "$V"; then
+            echo exists=true >> $GITHUB_OUTPUT
+          else
+            echo exists=false >> $GITHUB_OUTPUT
+          fi
+
+      - name: Publish blz-cli
+        if: steps.crate_cli_exists.outputs.exists != 'true'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p blz-cli --locked
+
+  publish-github-release:
+    name: "Publish: GitHub Release"
+    runs-on: ubuntu-latest
+    needs: [npm-publish, cargo-publish, bump-homebrew]
+    steps:
+      - name: "Undraft GitHub release"
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag || github.event.inputs.tag }}
+          draft: false
+          prerelease: false
+
+  bump-homebrew:
+    name: "Publish: Homebrew Tap"
+    runs-on: ubuntu-latest
+    needs: [npm-publish, cargo-publish]
+    steps:
+      - name: "Checkout source (for script)"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.event.inputs.tag }}
+          path: src
+
+      - name: "Compute version and download tarballs"
+        id: tar
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ inputs.tag || github.event.inputs.tag }}"
+          VERSION="${TAG#v}"
+          gh release download "$TAG" --repo "${{ github.repository }}" --pattern "blz-darwin-arm64.tar.gz" --dir . --clobber
+          gh release download "$TAG" --repo "${{ github.repository }}" --pattern "blz-darwin-x64.tar.gz" --dir . --clobber
+          SHA_ARM64=$(shasum -a 256 blz-darwin-arm64.tar.gz | cut -d' ' -f1)
+          SHA_X64=$(shasum -a 256 blz-darwin-x64.tar.gz | cut -d' ' -f1)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "sha_arm64=$SHA_ARM64" >> $GITHUB_OUTPUT
+          echo "sha_x64=$SHA_X64" >> $GITHUB_OUTPUT
+
+      - name: "Checkout tap repo"
+        uses: actions/checkout@v4
+        with:
+          repository: outfitter-dev/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: "Update formula"
+        shell: bash
+        env:
+          REPO: ${{ github.repository }}
+          VERSION: ${{ steps.tar.outputs.version }}
+          SHA_ARM64: ${{ steps.tar.outputs.sha_arm64 }}
+          SHA_X64: ${{ steps.tar.outputs.sha_x64 }}
+          TAP_DIR: homebrew-tap
+        run: |
+          bash src/scripts/release/update-brew.sh
+
+      - name: "Create PR in tap repo"
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+          branch: bump-blz-${{ steps.tar.outputs.version }}
+          commit-message: "blz ${{ steps.tar.outputs.version }}"
+          title: "blz ${{ steps.tar.outputs.version }}"
+          body: |
+            Bump blz formula to ${{ steps.tar.outputs.version }}.
+            - arm64 sha256: ${{ steps.tar.outputs.sha_arm64 }}
+            - x64   sha256: ${{ steps.tar.outputs.sha_x64 }}

--- a/.github/workflows/release-cached.yml
+++ b/.github/workflows/release-cached.yml
@@ -707,3 +707,11 @@ jobs:
               echo "🔨 Performed clean builds"
             fi
           } | tee -a "$GITHUB_STEP_SUMMARY"
+  publish:
+    name: "Publish: orchestrate"
+    runs-on: ubuntu-latest
+    needs: [prepare, build-darwin-arm64, build-darwin-x64, build-linux-x64, build-linux-arm64, build-windows-x64]
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag: v${{ needs.prepare.outputs.version }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -546,3 +546,10 @@ jobs:
           tag_name: ${{ inputs.tag }}
           draft: false
           prerelease: false
+  publish:
+    name: "Publish: orchestrate"
+    needs: [build-darwin-arm64, build-darwin-x64, build-linux-x64, build-linux-arm64, build-windows-x64]
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag: ${{ inputs.tag }}
+    secrets: inherit

--- a/scripts/release/update-brew.sh
+++ b/scripts/release/update-brew.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Updates the Homebrew tap formula for blz.
+#
+# Required environment variables:
+# - TAP_DIR: path to the checked out tap repo (default: homebrew-tap)
+# - REPO: GitHub repo in owner/name form (e.g., outfitter-dev/blz)
+# - VERSION: version string without leading v (e.g., 0.2.0)
+# - SHA_ARM64: sha256 for blz-darwin-arm64.tar.gz
+# - SHA_X64: sha256 for blz-darwin-x64.tar.gz
+
+TAP_DIR=${TAP_DIR:-homebrew-tap}
+REPO=${REPO:?REPO is required (e.g., outfitter-dev/blz)}
+VERSION=${VERSION:?VERSION is required (e.g., 0.2.0)}
+SHA_ARM64=${SHA_ARM64:?SHA_ARM64 is required}
+SHA_X64=${SHA_X64:?SHA_X64 is required}
+
+mkdir -p "$TAP_DIR/Formula"
+FORMULA_PATH="$TAP_DIR/Formula/blz.rb"
+
+cat > "$FORMULA_PATH" <<EOF
+class Blz < Formula
+  desc "Fast local search for llms.txt"
+  homepage "https://blz.run"
+  version "${VERSION}"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/${REPO}/releases/download/v\#{version}/blz-darwin-arm64.tar.gz"
+      sha256 "${SHA_ARM64}"
+    else
+      url "https://github.com/${REPO}/releases/download/v\#{version}/blz-darwin-x64.tar.gz"
+      sha256 "${SHA_X64}"
+    end
+  end
+
+  def install
+    bin.install "blz"
+  end
+end
+EOF
+
+echo "Updated formula at: $FORMULA_PATH"


### PR DESCRIPTION
This PR centralizes publishing into a reusable workflow and prepares the repo for npm Trusted Publishing.

Highlights
- New reusable workflow: .github/workflows/publish.yml
  - npm publish via OIDC + `--provenance` (no token)
  - crates.io publish (blz-core → wait for index → blz-cli)
  - Homebrew tap bump via script + PR to outfitter-dev/homebrew-tap
  - Undrafts the GitHub Release only after all publish steps succeed
- Callers updated:
  - release.yml: adds a final job that calls `publish.yml`
  - release-cached.yml: calls `publish.yml` as well
- Homebrew scripting
  - Added `scripts/release/update-brew.sh` to generate `Formula/blz.rb` cleanly (avoids heredocs in YAML)

Trusted Publisher setup
- In npm's Trusted Publishers UI, set the filename to `publish.yml`.
- No Environment Name needed.

Notes
- This PR does not remove the legacy publish jobs in release.yml yet; once we validate the reusable publish flow, we can remove/trim the old jobs safely.
- Homebrew tap requires `HOMEBREW_TAP_TOKEN` with write access to `outfitter-dev/homebrew-tap`.

After merge
- Re-run the release for tag v0.2.0 using the `publish.yml` path (or dispatch release.yml which will call `publish.yml`).
- Validate npm/crates/Homebrew and confirm the release undrafts automatically.
