### PR TITLE
fix(ci): install NASM for Windows release builds

### DIFF
--- a/.github/workflows/build-platform.yml
+++ b/.github/workflows/build-platform.yml
@@ -71,6 +71,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
 
+      - name: Install NASM (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          choco install nasm --yes --no-progress
+          'C:\\ProgramData\\chocolatey\\bin' | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       - name: Configure environment
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- install NASM via Chocolatey on Windows runners for the reusable release build workflow
- ensure the Chocolatey bin directory is appended to PATH so ring can find nasm.exe during builds

## Testing
- no automated tests (CI workflow change)

Closes #168.