### PR TITLE
fix(ci): add missing npm auth token for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,6 +69,8 @@ jobs:
       - name: npm publish (OIDC provenance)
         if: steps.npm_exists.outputs.exists != 'true'
         run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   cargo-publish:
     name: "Publish: crates.io"


### PR DESCRIPTION
## Summary
- Add missing `NODE_AUTH_TOKEN` environment variable to npm publish step
- The workflow was failing because npm authentication was not configured

## Details
The npm publish step in the publish workflow was failing with exit code 1 because it lacked the `NODE_AUTH_TOKEN` environment variable needed for authentication to the npm registry. Even when using OIDC provenance (`--provenance` flag), the auth token is still required for npm authentication.

## Test Plan
- [ ] Verify that the `NPM_TOKEN` secret is configured in the repository settings
- [ ] Next release workflow run should successfully publish to npm

Closes #168

🤖 Generated with [Claude Code](https://claude.ai/code)