### PR TITLE
fix(npm): update import syntax and decouple publish jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,8 @@ jobs:
   cargo-publish:
     name: "Publish: crates.io"
     runs-on: ubuntu-latest
-    needs: npm-publish
+    # Run independently - don't block on npm-publish
+    if: always()
     steps:
       - name: "Checkout tag"
         uses: actions/checkout@v4
@@ -156,7 +157,8 @@ jobs:
   bump-homebrew:
     name: "Publish: Homebrew Tap"
     runs-on: ubuntu-latest
-    needs: [npm-publish, cargo-publish]
+    # Run independently - don't wait for npm/cargo publish
+    if: always()
     steps:
       - name: "Checkout source (for script)"
         uses: actions/checkout@v4
@@ -217,7 +219,8 @@ jobs:
   finalize-github-release:
     name: "Publish: GitHub Release (undraft)"
     runs-on: ubuntu-latest
-    needs: [npm-publish, cargo-publish, bump-homebrew]
+    # Always run to undraft the release, even if some publish steps fail
+    if: always()
     steps:
       - name: "Undraft GitHub release"
         uses: softprops/action-gh-release@v2

--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -21,7 +21,8 @@ try {
     process.exit(0);
   }
 
-  const pkg = await import(join(dirname(__dirname), 'package.json'), { assert: { type: 'json' } });
+  const pkgUrl = new URL('../package.json', import.meta.url);
+  const pkg = await import(pkgUrl, { with: { type: 'json' } });
   const version = pkg.default.version;
   const p = platform();
   const a = arch();

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prepack": "node npm/prepack.js"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.20.0"
   },
   "os": [
     "darwin",


### PR DESCRIPTION
## Summary
- Fix npm postinstall script import attribute syntax
- Decouple publish workflow jobs to prevent cascading failures

## Changes
1. **npm/postinstall.js**: Update import syntax from deprecated `assert` to `with` for JSON import attributes (fixes Node.js compatibility issue)
2. **publish.yml**: Make all publish jobs independent with `if: always()` so they don't block each other

## Problem
The npm install was failing with:
```
Module "file:///path/to/package.json" needs an import attribute of "type: json"
```

Additionally, when npm publish failed (due to missing token), it blocked:
- crates.io publishing
- Homebrew tap update  
- GitHub release creation

## Solution
- Use modern `with` syntax for import attributes (Node.js 18.20+)
- Run all publish jobs independently so one failure doesn't cascade

## Test Plan
- [ ] npm install works locally with Node.js 20+
- [ ] Workflow jobs run independently in next release

Fixes the npm install issue reported by @galligan

🤖 Generated with [Claude Code](https://claude.ai/code)