### PR TITLE
chore(release): bump to v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2025-09-17
+
+### Changed
+- Automated releases via label-driven workflows that build cross-platform artifacts, upload them, and publish npm/crates/Homebrew in sequence.
+- Added asset readiness guards for the Homebrew job and tightened release undraft conditions to avoid incomplete releases.
+- Cached `cargo-edit` in CI and documented local `act` rehearsals for release workflows.
+
+### Fixed
+- Windows npm postinstall now imports `package.json` via URL (no `ERR_UNSUPPORTED_ESM_URL_SCHEME`) and the package requires Node ≥ 18.20.0.
+
 ## [0.2.0] - 2025-09-15
 
 ### Added
@@ -82,3 +92,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.6]: https://github.com/outfitter-dev/blz/releases/tag/v0.1.6
 [0.1.5]: https://github.com/outfitter-dev/blz/releases/tag/v0.1.5
 [0.1.7]: https://github.com/outfitter-dev/blz/releases/tag/v0.1.7
+[0.2.0]: https://github.com/outfitter-dev/blz/releases/tag/v0.2.0
+[0.2.1]: https://github.com/outfitter-dev/blz/releases/tag/v0.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "blz-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "blz-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["Outfitter Dev"]
 license = "MIT"
@@ -44,7 +44,7 @@ tempfile = "3"
 url = "2"
 
 # Internal crates (ensure version is set for crates.io publish of dependents)
-blz-core = { path = "crates/blz-core", version = "0.2.0" }
+blz-core = { path = "crates/blz-core", version = "0.2.1" }
 
 [patch.crates-io]
 # Work around macOS ARM CPU feature detection panic in ring 0.17.14
@@ -78,3 +78,7 @@ expect_used = "warn"
 panic = "warn"
 unimplemented = "warn"
 todo = { level = "warn", priority = 1 }
+
+[profile.release]
+lto = "thin"
+codegen-units = 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@outfitter/blz",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@outfitter/blz",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outfitter/blz",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Fast local llms.txt search for agents",
   "keywords": [
     "documentation",


### PR DESCRIPTION
## Summary
- bump Cargo workspace and npm package versions to 0.2.1 using the release script
- document release automation changes and Windows postinstall fix in the changelog

## Testing
- `./scripts/release/semver-bump.sh --check`
