### PR TITLE
feat(ci): add Linux support to Homebrew formula

### DIFF
--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -79,11 +79,12 @@ jobs:
           TAG='${{ steps.resolve.outputs.tag }}'
           ARM_COUNT=$(gh release view "$TAG" --repo "${{ github.repository }}" --json assets | jq -r --arg version "$VERSION" '.assets | map(select(.name == ("blz-"+$version+"-darwin-arm64.tar.gz"))) | length')
           X64_COUNT=$(gh release view "$TAG" --repo "${{ github.repository }}" --json assets | jq -r --arg version "$VERSION" '.assets | map(select(.name == ("blz-"+$version+"-darwin-x64.tar.gz"))) | length')
-          if [ "${ARM_COUNT:-0}" -eq 0 ] || [ "${X64_COUNT:-0}" -eq 0 ]; then
+          LINUX_COUNT=$(gh release view "$TAG" --repo "${{ github.repository }}" --json assets | jq -r --arg version "$VERSION" '.assets | map(select(.name == ("blz-"+$version+"-linux-x64.tar.gz"))) | length')
+          if [ "${ARM_COUNT:-0}" -eq 0 ] || [ "${X64_COUNT:-0}" -eq 0 ] || [ "${LINUX_COUNT:-0}" -eq 0 ]; then
             {
               echo "ready=false"
             } >> "$GITHUB_OUTPUT"
-            echo "Homebrew assets not ready for $TAG (arm64=$ARM_COUNT, x64=$X64_COUNT)" >> "$GITHUB_STEP_SUMMARY"
+            echo "Homebrew assets not ready for $TAG (arm64=$ARM_COUNT, x64=$X64_COUNT, linux=$LINUX_COUNT)" >> "$GITHUB_STEP_SUMMARY"
           else
             {
               echo "ready=true"
@@ -109,10 +110,15 @@ jobs:
           VERSION='${{ steps.resolve.outputs.version }}'
           gh release download "$TAG" --repo "${{ github.repository }}" --pattern "blz-${VERSION}-darwin-arm64.tar.gz" --dir . --clobber
           gh release download "$TAG" --repo "${{ github.repository }}" --pattern "blz-${VERSION}-darwin-x64.tar.gz" --dir . --clobber
+          gh release download "$TAG" --repo "${{ github.repository }}" --pattern "blz-${VERSION}-linux-x64.tar.gz" --dir . --clobber
           SHA_ARM64=$(shasum -a 256 blz-${VERSION}-darwin-arm64.tar.gz | cut -d' ' -f1)
           SHA_X64=$(shasum -a 256 blz-${VERSION}-darwin-x64.tar.gz | cut -d' ' -f1)
-          echo "sha_arm64=$SHA_ARM64" >> "$GITHUB_OUTPUT"
-          echo "sha_x64=$SHA_X64" >> "$GITHUB_OUTPUT"
+          SHA_LINUX=$(shasum -a 256 blz-${VERSION}-linux-x64.tar.gz | cut -d' ' -f1)
+          {
+            echo "sha_arm64=$SHA_ARM64"
+            echo "sha_x64=$SHA_X64"
+            echo "sha_linux=$SHA_LINUX"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Checkout tap repository
         if: ${{ steps.resolve.outputs.enabled == 'true' && steps.assets.outputs.ready == 'true' }}
@@ -130,6 +136,7 @@ jobs:
           VERSION: ${{ steps.resolve.outputs.version }}
           SHA_ARM64: ${{ steps.tar.outputs.sha_arm64 }}
           SHA_X64: ${{ steps.tar.outputs.sha_x64 }}
+          SHA_LINUX: ${{ steps.tar.outputs.sha_linux }}
           TAP_DIR: homebrew-tap
         run: |
           bash src/scripts/release/update-brew.sh
@@ -147,3 +154,4 @@ jobs:
             Bump blz formula to ${{ steps.resolve.outputs.version }}.
             - arm64 sha256: ${{ steps.tar.outputs.sha_arm64 }}
             - x64   sha256: ${{ steps.tar.outputs.sha_x64 }}
+            - linux sha256: ${{ steps.tar.outputs.sha_linux }}

--- a/docs/ci/release.yml.backup
+++ b/docs/ci/release.yml.backup
@@ -321,12 +321,16 @@ jobs:
             --pattern "blz-darwin-arm64.tar.gz" --dir . --clobber
           gh release download "$TAG" --repo "${{ github.repository }}" \
             --pattern "blz-darwin-x64.tar.gz" --dir . --clobber
+          gh release download "$TAG" --repo "${{ github.repository }}" \
+            --pattern "blz-linux-x64.tar.gz" --dir . --clobber
 
           SHA_ARM64=$(shasum -a 256 blz-darwin-arm64.tar.gz | cut -d' ' -f1)
           SHA_X64=$(shasum -a 256 blz-darwin-x64.tar.gz | cut -d' ' -f1)
+          SHA_LINUX=$(shasum -a 256 blz-linux-x64.tar.gz | cut -d' ' -f1)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "sha_arm64=$SHA_ARM64" >> $GITHUB_OUTPUT
           echo "sha_x64=$SHA_X64" >> $GITHUB_OUTPUT
+          echo "sha_linux=$SHA_LINUX" >> $GITHUB_OUTPUT
 
       - name: "Publish: Checkout tap repo"
         uses: actions/checkout@v4
@@ -352,14 +356,21 @@ jobs:
                   url "https://github.com/outfitter-dev/blz/releases/download/v${VERSION}/blz-darwin-x64.tar.gz"
                   sha256 "${SHA_X64}"
                 end
+              end
 
-                def install
-                  bin.install "blz"
+              on_linux do
+                on_intel do
+                  url "https://github.com/outfitter-dev/blz/releases/download/v${VERSION}/blz-linux-x64.tar.gz"
+                  sha256 "${SHA_LINUX}"
                 end
+              end
 
-                test do
-                  assert_match version.to_s, shell_output("#{bin}/blz --version")
-                end
+              def install
+                bin.install "blz"
+              end
+
+              test do
+                assert_match version.to_s, shell_output("#{bin}/blz --version")
               end
             end
         run: |
@@ -367,11 +378,13 @@ jobs:
           VERSION="${{ steps.tar.outputs.version }}"
           SHA_ARM64="${{ steps.tar.outputs.sha_arm64 }}"
           SHA_X64="${{ steps.tar.outputs.sha_x64 }}"
+          SHA_LINUX="${{ steps.tar.outputs.sha_linux }}"
           printf "%s\n" "$FORMULA" > homebrew-tap/Formula/blz.rb
           # Substitute placeholders after write to appease linters
           sed -i.bak "s/\${VERSION}/${VERSION}/g" homebrew-tap/Formula/blz.rb
           sed -i.bak "s/\${SHA_ARM64}/${SHA_ARM64}/g" homebrew-tap/Formula/blz.rb
           sed -i.bak "s/\${SHA_X64}/${SHA_X64}/g" homebrew-tap/Formula/blz.rb
+          sed -i.bak "s/\${SHA_LINUX}/${SHA_LINUX}/g" homebrew-tap/Formula/blz.rb
           rm -f homebrew-tap/Formula/blz.rb.bak
 
       - name: "Publish: Create PR in tap repo"

--- a/scripts/release/update-brew.sh
+++ b/scripts/release/update-brew.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 # - VERSION: version string without leading v (e.g., 0.2.0)
 # - SHA_ARM64: sha256 for blz-${VERSION}-darwin-arm64.tar.gz
 # - SHA_X64: sha256 for blz-${VERSION}-darwin-x64.tar.gz
+# - SHA_LINUX: sha256 for blz-${VERSION}-linux-x64.tar.gz
 
 TAP_DIR=${TAP_DIR:-homebrew-tap}
 REPO=${REPO:?REPO is required (e.g., outfitter-dev/blz)}
@@ -23,9 +24,10 @@ if [[ ! "$VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}([.-][0-9A-Za-z.-]+)?$ ]]; then
 fi
 SHA_ARM64=${SHA_ARM64:?SHA_ARM64 is required}
 SHA_X64=${SHA_X64:?SHA_X64 is required}
+SHA_LINUX=${SHA_LINUX:?SHA_LINUX is required}
 
 # Validate SHA256 inputs to fail fast on bad data (each must be 64 hex chars)
-for var in SHA_ARM64 SHA_X64; do
+for var in SHA_ARM64 SHA_X64 SHA_LINUX; do
   val="${!var}"
   if [[ ! "$val" =~ ^[0-9a-fA-F]{64}$ ]]; then
     echo "Invalid $var: must be 64 hex characters" >&2
@@ -58,6 +60,13 @@ class Blz < Formula
     on_intel do
       url "https://github.com/${REPO}/releases/download/v#{version}/blz-#{version}-darwin-x64.tar.gz"
       sha256 "${SHA_X64}"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/${REPO}/releases/download/v#{version}/blz-#{version}-linux-x64.tar.gz"
+      sha256 "${SHA_LINUX}"
     end
   end
 


### PR DESCRIPTION
# Add Linux x64 support to Homebrew formula

This PR adds Linux x64 support to our Homebrew formula, allowing users to install `blz` on Linux systems via Homebrew.

Changes include:
- Updated the Homebrew formula to include Linux x64 binary download information
- Modified the GitHub workflow to check for Linux assets before publishing
- Added Linux SHA256 checksum calculation and verification
- Updated the PR description template to include Linux SHA information

The workflow now downloads and verifies all three platform binaries (macOS arm64, macOS x64, and Linux x64) before updating the formula.