### PR TITLE
chore(ci): auto-release dispatch publish workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -9,6 +9,7 @@ on:
       - main
 
 permissions:
+  actions: write
   contents: write
   pull-requests: read
   issues: write
@@ -156,6 +157,7 @@ jobs:
       prerelease: ${{ steps.meta.outputs.prerelease }}
       mode: ${{ needs.detect.outputs.mode }}
       pr_number: ${{ needs.detect.outputs.pr_number }}
+      committed: ${{ steps.commit.outputs.committed || 'false' }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- grant Auto Release workflow Actions:write permission and expose whether a release commit was created
- rely on the existing v* tag push to trigger publish.yml, avoiding duplicate runs

## Testing
- cargo clippy --workspace --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation configuration by adjusting permissions and adding an output indicating whether a commit occurred during the release step.
  * These changes affect only the release pipeline and do not alter product features, performance, or UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->