### PR TITLE
fix(cli): use flavor-aware content loading for text formatter snippets

### DIFF
--- a/crates/blz-cli/tests/search_flavor.rs
+++ b/crates/blz-cli/tests/search_flavor.rs
@@ -153,3 +153,135 @@ async fn search_defaults_to_base_flavor_and_respects_override() -> anyhow::Resul
 
     Ok(())
 }
+
+#[tokio::test]
+async fn text_formatter_uses_correct_flavor_for_snippets() -> anyhow::Result<()> {
+    let data_dir = tempdir()?;
+    let server = MockServer::start().await;
+
+    // Create two flavors with DIFFERENT content at the same lines
+    // This is critical: if formatter loads wrong flavor, snippets will be incorrect
+    let base_doc = r#"# API Documentation
+
+## Authentication
+Line 4: Base flavor authentication method
+Line 5: Use API key in header
+
+## Rate Limits
+Line 8: Base flavor rate limit info
+"#;
+
+    let full_doc = r#"# API Documentation
+
+## Authentication
+Line 4: FULL FLAVOR authentication with OAuth2
+Line 5: Detailed OAuth2 flow explanation
+
+## Rate Limits
+Line 8: FULL FLAVOR detailed rate limit tiers
+"#;
+
+    // Setup mock server
+    Mock::given(method("HEAD"))
+        .and(path("/llms.txt"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+    Mock::given(method("HEAD"))
+        .and(path("/llms-full.txt"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/llms.txt"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(base_doc))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/llms-full.txt"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(full_doc))
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/llms.txt", server.uri());
+
+    // Add source
+    blz_cmd()
+        .env("BLZ_DATA_DIR", data_dir.path())
+        .env("BLZ_PREFER_LLMS_FULL", "0")
+        .env("BLZ_CONFIG_DIR", data_dir.path())
+        .args(["add", "api", &url, "-y"])
+        .assert()
+        .success();
+
+    // Search full flavor in TEXT format and capture output
+    let output = blz_cmd()
+        .env("BLZ_DATA_DIR", data_dir.path())
+        .env("BLZ_PREFER_LLMS_FULL", "0")
+        .env("BLZ_CONFIG_DIR", data_dir.path())
+        .args([
+            "search",
+            "authentication",
+            "--flavor",
+            "full",
+            "--format",
+            "text",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8_lossy(&output);
+
+    // Critical assertion: text output MUST contain snippets from FULL flavor, not base
+    assert!(
+        stdout.contains("FULL FLAVOR"),
+        "Text formatter must display snippets from full flavor when searching full flavor.\n\
+         Expected 'FULL FLAVOR' in output but got:\n{}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("Base flavor"),
+        "Text formatter must NOT display snippets from base flavor when searching full flavor.\n\
+         Found 'Base flavor' in output:\n{}",
+        stdout
+    );
+
+    // Verify the opposite: searching base flavor shows base snippets
+    let output = blz_cmd()
+        .env("BLZ_DATA_DIR", data_dir.path())
+        .env("BLZ_PREFER_LLMS_FULL", "0")
+        .env("BLZ_CONFIG_DIR", data_dir.path())
+        .args([
+            "search",
+            "authentication",
+            "--flavor",
+            "txt",
+            "--format",
+            "text",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8_lossy(&output);
+
+    assert!(
+        stdout.contains("Base flavor"),
+        "Text formatter must display snippets from base flavor when searching base flavor.\n\
+         Expected 'Base flavor' in output but got:\n{}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("FULL FLAVOR"),
+        "Text formatter must NOT display snippets from full flavor when searching base flavor.\n\
+         Found 'FULL FLAVOR' in output:\n{}",
+        stdout
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
The text formatter was loading llms.txt content without considering which
flavor (txt vs full) the search hit came from. This caused line number
mismatches and incorrect snippets when searching against llms-full.txt.

Changes:
- Modified cache key to include flavor: alias:flavor format
- Updated load_llms_lines() to accept flavor parameter
- Use storage.flavor_file_path() instead of llms_txt_path()
- Extract flavor from SearchHit.flavor field with txt fallback

Now snippets correctly display content from the same flavor file that was
searched, fixing the issue where all text results showed identical/incorrect
snippets.

Fixes #232