### PR TITLE
chore(npm): bump package.json to 1.0.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,9 @@
         "linux",
         "win32"
       ],
-      "version": "0.4.1"
+      "version": "1.0.0-beta.1"
     }
   },
   "requires": true,
-  "version": "0.4.1"
+  "version": "1.0.0-beta.1"
 }

--- a/package.json
+++ b/package.json
@@ -57,5 +57,5 @@
     "prepack": "node npm/prepack.js"
   },
   "type": "module",
-  "version": "0.4.1"
+  "version": "1.0.0-beta.1"
 }


### PR DESCRIPTION
Update package.json version to match v1.0.0-beta.1 release tag.
This will allow the npm publish workflow to succeed.

[skip ci]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 1.0.0-beta.1 (pre-release).
  * No functional changes included in this release.
  * Consumers will see the new version when installing or updating the package.
  * Dependency managers and semantic versioning ranges may resolve to this pre-release if explicitly allowed.
  * Published artifacts and release metadata will reflect 1.0.0-beta.1.
  * Users can pin or test against this beta version ahead of a stable release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->