### PR TITLE
feat(docs): add bundled documentation hub and Linear integration rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-10-09
+
+### Added
+- **Bundled documentation hub**: New `blz docs` command with subcommands for embedded documentation
+  - `blz docs search`: Search the bundled blz-docs source without touching other aliases
+  - `blz docs sync`: Sync or resync embedded documentation files and index
+  - `blz docs overview`: Quick-start guide for humans and agents
+  - `blz docs cat`: Print entire bundled llms-full.txt to stdout
+  - `blz docs export`: Export CLI docs in markdown or JSON (replaces old `blz docs --format`)
+- **Internal documentation source**: `blz-docs` alias (also `@blz`) ships with the binary
+  - Hidden from default search with `internal` tag
+  - Auto-syncs on first use or when version changes
+  - Full CLI reference and user guide embedded in the binary
+- **Linear integration rules**: Added `.agents/rules/LINEAR.md` for Linear project management workflow
+
+### Changed
+- `blz docs` command now uses subcommands instead of single `--format` flag
+  - Old `blz docs --format json` still works for backward compatibility
+  - New preferred syntax: `blz docs export --format json`
+
+### Internal
+- Added `DocsCommands` enum for `blz docs` subcommands
+- Added `DocsSearchArgs` for bundled docs search functionality
+- New `docs_bundle.rs` module for managing embedded documentation
+
 ## [1.0.0-beta.1] - 2025-10-03
 
 ### Breaking Changes
@@ -274,6 +299,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ETag-based conditional fetching for efficiency
 - Local filesystem storage with archive support
 
+[1.0.1]: https://github.com/outfitter-dev/blz/releases/tag/v1.0.1
 [1.0.0-beta.1]: https://github.com/outfitter-dev/blz/releases/tag/v1.0.0-beta.1
 [0.5.0]: https://github.com/outfitter-dev/blz/releases/tag/v0.5.0
 [0.4.1]: https://github.com/outfitter-dev/blz/releases/tag/v0.4.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "blz-cli"
-version = "1.0.0-beta.1"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "blz-core"
-version = "1.0.0-beta.1"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "blz-registry-build"
-version = "1.0.0-beta.1"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "blz-release"
-version = "1.0.0-beta.1"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0-beta.1"
+version = "1.0.1"
 edition = "2024"
 authors = ["Outfitter Dev"]
 license = "MIT"
@@ -56,7 +56,7 @@ is-terminal = "0.4"
 fs2 = "0.4"
 
 # Internal crates (ensure version is set for crates.io publish of dependents)
-blz-core = { path = "crates/blz-core", version = "1.0.0-beta.1" }
+blz-core = { path = "crates/blz-core", version = "1.0.1" }
 
 [patch.crates-io]
 # Work around macOS ARM CPU feature detection panic in ring 0.17.14


### PR DESCRIPTION
## Summary

Bumps workspace version from 1.0.0-beta.1 to 1.0.1 and updates CHANGELOG.md with release notes for v1.0.1.

## Changes

- Update workspace version to 1.0.1 in Cargo.toml
- Add v1.0.1 section to CHANGELOG.md documenting all changes in this release
- Update Cargo.lock with version changes

## Details

This is a preparation commit for the v1.0.1 release. The CHANGELOG includes:

**Added:**
- Bundled documentation hub with `blz docs` command and subcommands
- Internal `blz-docs` alias (also `@blz`) shipping with the binary
- Linear integration rules in `.agents/rules/LINEAR.md`

**Changed:**
- `blz docs` now uses subcommands instead of single `--format` flag
- Old syntax (`blz docs --format json`) maintained for backward compatibility
- New preferred syntax: `blz docs export --format json`

**Internal:**
- Added `DocsCommands` enum and `DocsSearchArgs`
- New `docs_bundle.rs` module for managing embedded documentation

Files changed:
- CHANGELOG.md (26 additions) - Added v1.0.1 release notes
- Cargo.toml (4 changes) - Version bump to 1.0.1
- Cargo.lock (8 changes) - Version propagation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a 1.0.1 changelog section outlining Added, Changed, and Internal notes and included a download/redirect link for the release.

* **Chores**
  * Bumped workspace package version to 1.0.1.
  * Aligned internal dependency versions with the 1.0.1 release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->