### PR TITLE
feat(search): add --max-chars option to control snippet length

### DIFF
--- a/crates/blz-cli/src/cli.rs
+++ b/crates/blz-cli/src/cli.rs
@@ -351,6 +351,14 @@ pub enum Commands {
             default_value_t = 3
         )]
         snippet_lines: u8,
+        /// Maximum total characters in snippet (including newlines). Range: 50-1000, default: 200.
+        #[arg(
+            long = "max-chars",
+            value_name = "CHARS",
+            env = "BLZ_MAX_CHARS",
+            value_parser = clap::value_parser!(usize)
+        )]
+        max_chars: Option<usize>,
         /// Return surrounding context lines or full section (defaults to 5 lines when no value supplied)
         ///
         /// Use 'all' to return the full heading block containing each hit.
@@ -591,6 +599,9 @@ pub struct DocsSearchArgs {
     /// Number of snippet lines to include per hit.
     #[arg(long, default_value_t = 4, value_name = "LINES")]
     pub snippet_lines: u8,
+    /// Maximum total characters in snippet (including newlines). Range: 50-1000, default: 200.
+    #[arg(long = "max-chars", value_name = "CHARS", value_parser = clap::value_parser!(usize))]
+    pub max_chars: Option<usize>,
     /// Add surrounding context lines.
     #[arg(long, value_name = "LINES")]
     pub context: Option<usize>,

--- a/crates/blz-cli/src/commands/mod.rs
+++ b/crates/blz-cli/src/commands/mod.rs
@@ -49,6 +49,7 @@ pub use info::execute_info;
 pub use list::execute as list_sources;
 pub use lookup::execute as lookup_registry;
 pub use remove::execute as remove_source;
+pub use search::{DEFAULT_MAX_CHARS, clamp_max_chars};
 pub use search::{execute as search, handle_default as handle_default_search};
 pub use stats::execute as show_stats;
 pub use update::{execute as update_source, execute_all as update_all};

--- a/crates/blz-cli/src/lib.rs
+++ b/crates/blz-cli/src/lib.rs
@@ -507,6 +507,7 @@ async fn execute_command(
             no_summary,
             score_precision,
             snippet_lines,
+            max_chars,
             context,
             block,
             max_lines,
@@ -528,6 +529,7 @@ async fn execute_command(
                 no_summary,
                 score_precision,
                 snippet_lines,
+                max_chars,
                 context,
                 block,
                 max_lines,
@@ -710,6 +712,7 @@ async fn docs_search(args: DocsSearchArgs, quiet: bool, metrics: PerformanceMetr
         args.no_summary,
         args.score_precision,
         args.snippet_lines,
+        args.max_chars.unwrap_or(commands::DEFAULT_MAX_CHARS),
         context_mode.as_ref(),
         args.block,
         args.max_block_lines,
@@ -865,6 +868,7 @@ async fn handle_search(
     no_summary: bool,
     score_precision: Option<u8>,
     snippet_lines: u8,
+    max_chars: Option<usize>,
     context: Option<crate::cli::ContextMode>,
     block: bool,
     max_lines: Option<usize>,
@@ -936,6 +940,7 @@ async fn handle_search(
     } else {
         limit.unwrap_or(DEFAULT_LIMIT)
     };
+    let actual_max_chars = max_chars.map_or(commands::DEFAULT_MAX_CHARS, commands::clamp_max_chars);
     let mut actual_page = page;
 
     if let Some(entry) = history_entry.as_ref() {
@@ -996,6 +1001,7 @@ async fn handle_search(
         no_summary,
         score_precision,
         snippet_lines,
+        actual_max_chars,
         context.as_ref(),
         block,
         max_lines,

--- a/crates/blz-cli/src/prompts/search.prompt.json
+++ b/crates/blz-cli/src/prompts/search.prompt.json
@@ -23,6 +23,7 @@
     { "flag": "--next / --last", "impact": "Traverse pagination without manually tracking page numbers." },
     { "flag": "--top <percent>", "impact": "Keep only top percentile of hits (post-pagination) to reduce noise." },
     { "flag": "--show <components>", "impact": "Augment text output (when not using JSON) with rank/url/anchor metadata." },
+    { "flag": "--max-chars <N>", "impact": "Control snippet length in total characters (default: 200, range: 50-1000). Higher values provide more context for relevance assessment without fetching full content." },
     { "flag": "--context all / --block (legacy)", "impact": "Returns full sections around each hit for one-shot retrieval. Use --max-lines to cap output size." },
     { "flag": "--context <N>", "impact": "Adds ±N lines of context around each hit for lighter-weight expansion." }
   ],

--- a/docs/agents/use-blz.md
+++ b/docs/agents/use-blz.md
@@ -44,6 +44,33 @@ blz "test runner" --json
 
 # Narrow the scope
 blz "test reporters" --json
+
+# Control snippet length (default: 200 chars, range: 50-1000)
+blz "api documentation" --max-chars 300 --json  # Longer snippets for better context
+blz "quick reference" --max-chars 100 --json     # Shorter snippets to save tokens
+```
+
+### Tuning Snippet Length
+
+The `--max-chars` flag controls the total character count of snippets returned in search results, including newlines and all text:
+
+- **Default**: 200 characters provides good balance between context and token efficiency
+- **Range**: 50-1000 characters (values outside this range are automatically clamped)
+- **Environment**: Set `BLZ_MAX_CHARS` to change the default for all searches
+- **Use cases**:
+  - **50-100 chars**: Minimal snippets when you just need to identify relevant sections
+  - **200 chars** (default): Good balance for assessing relevance without fetching full content
+  - **300-500 chars**: More context for complex topics or when you need better relevance signals
+  - **500-1000 chars**: Maximum context before fetching full sections with `blz get`
+
+Example workflow:
+
+```bash
+# Quick scan with short snippets
+blz "error handling" --max-chars 100 --json | jq -r '.[0:3] | .[] | .alias + ":" + .lines'
+
+# Detailed assessment with longer snippets
+blz "authentication flow" --max-chars 400 --json | jq '.[0] | {heading: .headingPath, snippet}'
 ```
 
 ## Retrieve Content

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -189,6 +189,8 @@ blz search <QUERY> [OPTIONS]
 - `--all` - Show all results (no limit)
 - `--page <N>` - Page number for pagination (default: 1)
 - `--top <N>` - Show only top N percentile of results (1-100)
+- `--max-chars <CHARS>` - Limit snippet length (default 200; clamps between 50 and 1000).
+  - Environment: `BLZ_MAX_CHARS` adjusts the default for implicit searches.
 - `--flavor <MODE>` - Override flavor for this run (`current`, `auto`, `full`, `txt`)
 - `-f, --format <FORMAT>` - Output format: `text` (default), `json`, or `jsonl`
   - Environment default: set `BLZ_OUTPUT_FORMAT=json|text|jsonl` to avoid passing `--format` each time (alias `ndjson` still accepted)


### PR DESCRIPTION
## Summary

Adds `--max-chars` flag to control snippet length in search results, providing fine-grained control over the balance between context and token efficiency. Default raised from ~100 to 200 characters based on reviewer feedback.

## Changes

- Add `--max-chars` parameter to `search` command with 200 character default
- Implement character limit clamping between 50-1000 characters via `clamp_max_chars()`
- Add `BLZ_MAX_CHARS` environment variable support for setting custom defaults
- Modify search engine core to respect character limits when generating snippets
- Add `DEFAULT_MAX_CHARS`, `MIN_SNIPPET_CHAR_LIMIT`, `MAX_SNIPPET_CHAR_LIMIT` constants
- Update comprehensive documentation with examples and use cases
- Add unit test `test_clamp_max_chars_bounds` to verify clamping behavior

## Details

**Problem:** Search result snippets were truncated at ~100 characters, making it harder to assess relevance without fetching full context. Reviewer feedback: "~200 character snippets instead of ~100 would help assess relevance without needing to fetch full content."

**Solution:** The `--max-chars` flag counts **total characters across the entire snippet** (all lines, including newlines), NOT per-line column width.

**Use cases:**
- **50-100 chars**: Minimal snippets when just identifying relevant sections
- **200 chars** (default): Good balance for assessing relevance without fetching full content
- **300-500 chars**: More context for complex topics or better relevance signals
- **500-1000 chars**: Maximum context before fetching full sections with `blz get`

**Examples:**
```bash
# Default behavior (200 total chars)
blz search "streaming" -s ai-sdk --json

# Shorter snippets to save tokens
blz search "quick reference" --max-chars 100 --json

# Longer snippets for complex topics
blz search "api documentation" --max-chars 300 --json

# Set custom default via environment
export BLZ_MAX_CHARS=250
blz search "authentication" --json
```

Files changed:
- crates/blz-core/src/index.rs (76 additions) - Core snippet generation logic with character limits
- crates/blz-cli/src/commands/search.rs (45 changes) - Integration and clamping logic
- crates/blz-cli/src/cli.rs (11 additions) - Add `--max-chars` flag to Search command
- docs/agents/use-blz.md (27 additions) - Agent usage guidance with tuning examples
- docs/cli/commands.md (2 additions) - CLI reference
- crates/blz-cli/src/prompts/search.prompt.json (1 addition) - Prompt documentation

Closes: BLZ-117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added --max-chars option to control total snippet length in search and docs search (default 200; clamped between 50–1000).
  - BLZ_MAX_CHARS environment variable can set a default for searches.
  - Searches and docs search flows now respect the configured snippet length across results.

- **Documentation**
  - Updated CLI and usage guides with flag details, clamping behavior, and examples for short/long snippet workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->