### PR TITLE
feat(cli): deprecate --snippet-lines flag in favor of --max-chars

### DIFF
--- a/crates/blz-cli/src/cli.rs
+++ b/crates/blz-cli/src/cli.rs
@@ -351,7 +351,8 @@ pub enum Commands {
             value_name = "LINES",
             value_parser = clap::value_parser!(u8).range(1..=10),
             env = "BLZ_SNIPPET_LINES",
-            default_value_t = 3
+            default_value_t = 3,
+            hide = true
         )]
         snippet_lines: u8,
         /// Maximum total characters in snippet (including newlines). Range: 50-1000, default: 200.
@@ -606,7 +607,7 @@ pub struct DocsSearchArgs {
     #[arg(long)]
     pub no_summary: bool,
     /// Number of snippet lines to include per hit.
-    #[arg(long, default_value_t = 4, value_name = "LINES")]
+    #[arg(long, default_value_t = 4, value_name = "LINES", hide = true)]
     pub snippet_lines: u8,
     /// Maximum total characters in snippet (including newlines). Range: 50-1000, default: 200.
     #[arg(long = "max-chars", value_name = "CHARS", value_parser = clap::value_parser!(usize))]

--- a/crates/blz-cli/src/lib.rs
+++ b/crates/blz-cli/src/lib.rs
@@ -886,8 +886,19 @@ async fn handle_search(
 ) -> Result<()> {
     const DEFAULT_LIMIT: usize = 50;
     const ALL_RESULTS_LIMIT: usize = 10_000;
+    const DEFAULT_SNIPPET_LINES: u8 = 3;
+
     let provided_query = query.is_some();
     let limit_was_explicit = all || limit.is_some();
+
+    // Emit deprecation warning if --snippet-lines was explicitly set
+    if snippet_lines != DEFAULT_SNIPPET_LINES {
+        let args: Vec<String> = std::env::args().collect();
+        if flag_present(&args, "--snippet-lines") || std::env::var("BLZ_SNIPPET_LINES").is_ok() {
+            // Pass false for quiet - the deprecation function handles quiet mode internally
+            utils::cli_args::emit_snippet_lines_deprecation(false);
+        }
+    }
 
     if next {
         if provided_query {


### PR DESCRIPTION
## Summary

Deprecates the `--snippet-lines` flag in favor of `--max-chars`, preparing for its removal in v2.0. The flag remains functional but is hidden from help output and emits a deprecation warning when used.

## Changes

- Hide `--snippet-lines` flag from help output by adding `hide = true` to argument definitions
- Add deprecation warning when flag is explicitly set via CLI or `BLZ_SNIPPET_LINES` environment variable
- Implement warning mechanism that respects quiet mode and only shows once per session
- Add `emit_snippet_lines_deprecation()` function in `cli_args.rs` with session-based tracking
- Add `BLZ_SUPPRESS_DEPRECATIONS` environment variable support
- Comprehensive test coverage (5 new tests) for deprecation warning behavior

## Details

**Problem:** With the introduction of `--max-chars` flag (BLZ-117), having both `--snippet-lines` and `--max-chars` creates confusion and duplicates functionality. The character-based approach provides better control over snippet length.

**Solution:** Graceful deprecation path:
1. **v1.0.1**: Hide flag from help, emit deprecation warning, suggest `--max-chars`
2. **v2.0**: Remove flag entirely

**Warning behavior:**
- Emits once per session to avoid spam
- Respects quiet mode (`-q` / `--quiet`)
- Can be suppressed with `BLZ_SUPPRESS_DEPRECATIONS=1`
- Only warns when flag is explicitly used (not when using default value)

**Example warning:**
```
warning: --snippet-lines is deprecated; use --max-chars instead. This flag will be removed in v2.0.
```

**Migration path:**
```bash
# Old (deprecated)
blz search "query" --snippet-lines 5

# New (recommended)
blz search "query" --max-chars 300
```

Files changed:
- crates/blz-cli/src/utils/cli_args.rs (102 additions) - Deprecation warning implementation and tests
- crates/blz-cli/src/lib.rs (11 additions) - Flag detection and warning trigger
- crates/blz-cli/src/cli.rs (5 changes) - Hide flag from help output

Tests added:
- `snippet_lines_deprecation_sets_warning_flag_once`
- `snippet_lines_deprecation_suppressed_when_quiet`
- `snippet_lines_deprecation_suppressed_with_env_var`
- `snippet_lines_deprecation_only_warns_once_per_session`

Closes: BLZ-133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Deprecated the snippet-lines CLI option: using it now emits a one-time deprecation warning per session.
  - The snippet-lines parameter is hidden from help/usage output.
  - Deprecation warning respects quiet mode and an environment variable to suppress deprecations.

- **Tests**
  - Added tests ensuring the deprecation warning triggers once, respects quiet mode, and can be suppressed via environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->