### PR TITLE
fix(cli): improve bundled docs search error messaging and format handling [BLZ-151]

### DIFF
--- a/crates/blz-cli/src/cli.rs
+++ b/crates/blz-cli/src/cli.rs
@@ -234,9 +234,6 @@ pub enum Commands {
     Docs {
         #[command(subcommand)]
         command: Option<DocsCommands>,
-        /// Back-compat: `blz docs --format json` still exports CLI docs
-        #[arg(long = "format", value_enum)]
-        format: Option<crate::commands::DocsFormat>,
     },
 
     /// Anchor utilities


### PR DESCRIPTION
## Summary

Improves user experience when bundled documentation is unavailable by detecting placeholder content and providing clear, actionable error messages. Also fixes format flag parsing for the `blz docs` command.

## Changes

- **Placeholder content detection**: Checks for placeholder content before attempting search operations
  - Detects `# BLZ bundled docs (placeholder)` marker in bundled docs
  - Prevents confusing "search failed" errors with generic messages

- **Format-specific error output**: Provides appropriate error messages based on output format
  - **JSON mode**: Structured error with `error`, `reason`, and `suggestions` fields
  - **Text mode**: User-friendly message with clear alternatives and next steps
  - Suggests actionable commands: `blz docs overview` and `blz docs export`

- **Fixed format flag handling**: Removed conflicting parent-level `--format` flag from `Docs` command
  - Format aliases (`--json`, `--text`) now work correctly when placed before the query
  - Only converts format aliases to `--format` when injecting implicit search
  - Preserves original flags for explicit subcommands for proper Clap parsing

- **Simplified fallback behavior**: When no subcommand is provided, always show overview
  - Removed legacy format fallback to export
  - Consistent behavior: `blz docs` always shows overview

## Details

### Problem Solved

Users encountering placeholder bundled docs received a confusing generic error:
```bash
blz docs search "format json" --json
# Warning: Search failed: search failed for source=blz-docs
```

This didn't explain the placeholder state or provide guidance on alternatives.

### New Behavior

**JSON Output**:
```json
{
  "error": "Bundled documentation content not yet available",
  "reason": "The blz-docs source currently contains placeholder content",
  "suggestions": [
    "Use 'blz docs overview' for quick-start information",
    "Use 'blz docs export' to view CLI documentation",
    "Full bundled documentation will be included in a future release"
  ]
}
```

**Text Output**:
```
Error: Bundled documentation content not yet available.

The blz-docs source currently contains placeholder content.

Suggestions:
  • Use 'blz docs overview' for quick-start information
  • Use 'blz docs export' to view CLI documentation
  • Full bundled documentation will be included in a future release
```

## Files Changed

- `crates/blz-cli/src/cli.rs` (3 deletions)
  - Removed `format` field from `Docs` command struct
  - Eliminated conflicting parent-level format flag

- `crates/blz-cli/src/lib.rs` (48 additions, 13 deletions)
  - Added placeholder content detection in `docs_search()`
  - Implemented format-specific error messages (JSON and text)
  - Fixed format flag conversion logic in `preprocess_args_from()`
  - Simplified `handle_docs()` by removing legacy format parameter
  - Updated docs fallback behavior to always show overview

Closes: BLZ-151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docs search now detects placeholder content and shows a clear user message or structured JSON error when output is JSON.

* **Refactor**
  * Removed the legacy --format option from the docs command.
  * No-subcommand docs now default to the overview.
  * Format alias injection is only applied for the search path; explicit format flags are preserved elsewhere.

* **Tests**
  * Updated tests for new default routing, preserved flag behavior, and placeholder-content error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->