### PR TITLE
feat(search): add fuzzy-matched source warnings for non-existent sources [BLZ-154]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.1] - 2025-10-09
 
 ### Added
+- **Fuzzy-matched source warnings**: When searching with a non-existent source filter, `blz` now suggests similar source names
+  - Shows top 3 closest matches sorted by similarity score
+  - Warnings print to stderr only (preserves JSON output on stdout)
+  - Respects quiet mode (`-q` flag) to suppress warnings
+  - Exit code remains 0 for backward compatibility
 - **Bundled documentation hub**: New `blz docs` command with subcommands for embedded documentation
   - `blz docs search`: Search the bundled blz-docs source without touching other aliases
   - `blz docs sync`: Sync or resync embedded documentation files and index

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,7 @@ dependencies = [
  "directories",
  "fs2",
  "futures",
+ "fuzzy-matcher",
  "indicatif",
  "is-terminal",
  "once_cell",

--- a/crates/blz-cli/Cargo.toml
+++ b/crates/blz-cli/Cargo.toml
@@ -40,6 +40,7 @@ futures.workspace = true
 url.workspace = true
 toml_edit.workspace = true
 toml.workspace = true
+fuzzy-matcher.workspace = true
 
 # CLI-specific
 colored = "2"


### PR DESCRIPTION
## Summary

Adds intelligent fuzzy-matched suggestions when users search with non-existent source filters, helping them recover from typos without interrupting their workflow. Warnings print to stderr while preserving clean JSON output on stdout.

## Changes

- **Fuzzy matching for typo recovery**: Uses `fuzzy-matcher` crate with Skim algorithm
    - Suggests up to 3 closest matches sorted by similarity score
    - Filters suggestions to positive scores only (meaningful matches)
    - Falls back to generic warning if no similar sources found
- **Smart warning output**:
    - Warnings print to stderr only, preserving JSON output on stdout
    - Respects quiet mode (`-q` flag) to suppress warnings
    - Provides actionable guidance: "Run 'blz list' to see all sources"
- **Backward compatible behavior**:
    - Exit code remains 0 (non-existent source = search empty set)
    - Empty results returned as valid JSON
    - Existing scripts and automation unaffected
- **Extended** **`SearchOptions`** **struct**: Added `quiet` field to control warning output

## Details

### Problem Solved

When users mistyped source names, they received empty results with no feedback:

```
blz search "test" -s typscript --json
# Returns: []
# No indication of the typo
```

This led to confusion and time wasted debugging "why no results?"

### New Behavior

**Example 1: Single suggestion**

```
blz search "hooks" -s typscript
# Warning: Source 'typscript' not found. Did you mean: typescript?
# Run 'blz list' to see all sources.
```

**Example 2: Multiple suggestions**

```
blz search "api" -s ai
# Warning: Source 'ai' not found. Did you mean: ai-sdk, ai-jsx, airbyte?
# Run 'blz list' to see all sources.
```

**Example 3: No close matches**

```
blz search "test" -s nonexistent
# Warning: Source 'nonexistent' not found.
# Run 'blz list' to see all sources.
```

**Example 4: Quiet mode suppresses warnings**

```
blz search "test" -s typscript -q
# (no warning output)
```

### Implementation Details

Uses the Skim V2 fuzzy matcher (same algorithm as the fzf tool) for:

- Fast substring and fuzzy matching
- Scoring based on character position and continuity
- Efficient filtering of poor matches

The matcher compares the requested source name against all available sources, sorts by score descending, and takes the top 3 matches.

## Files Changed

- `crates/blz-cli/Cargo.toml` (1 addition)
    - Added `fuzzy-matcher` dependency
- `crates/blz-cli/src/commands/search.rs` (307 additions, 1 deletion)
    - Implemented fuzzy matching logic in source resolution
    - Added warning output to stderr with suggestions
    - Extended `SearchOptions` with `quiet` field
    - Updated all test fixtures to include `quiet: false`
- `crates/blz-cli/src/lib.rs` (17 additions, 1 deletion)
    - Propagated `quiet` flag through search execution paths
    - Updated `execute()` and `handle_default()` signatures
- `CHANGELOG.md` (5 additions)
    - Added entry for fuzzy-matched source warnings feature
- `Cargo.lock` (1 addition)
    - Locked `fuzzy-matcher` version

Closes: BLZ-154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now suggests up to the top 3 closest source name matches when a non-existent source filter is used (fuzzy matching).
  * Suggestions are emitted as warnings to stderr, honor quiet mode (-q), and preserve a successful exit code (0).

* **Documentation**
  * Changelog updated for version 1.0.1 to describe fuzzy-match suggestions and quiet-mode behavior.

* **Tests**
  * Added tests covering fuzzy-match suggestions and quiet-mode scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->