### PR TITLE
chore(release): prepare v1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "blz-cli"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "blz-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "blz-registry-build"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "blz-release"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 authors = ["Outfitter Dev"]
 license = "MIT"
@@ -56,7 +56,7 @@ is-terminal = "0.4"
 fs2 = "0.4"
 
 # Internal crates (ensure version is set for crates.io publish of dependents)
-blz-core = { path = "crates/blz-core", version = "1.1.0" }
+blz-core = { path = "crates/blz-core", version = "1.1.1" }
 
 [patch.crates-io]
 # Work around macOS ARM CPU feature detection panic in ring 0.17.14

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,9 @@
         "linux",
         "win32"
       ],
-      "version": "1.1.0"
+      "version": "1.1.1"
     }
   },
   "requires": true,
-  "version": "1.1.0"
+  "version": "1.1.1"
 }

--- a/package.json
+++ b/package.json
@@ -57,5 +57,5 @@
     "prepack": "node npm/prepack.js"
   },
   "type": "module",
-  "version": "1.1.0"
+  "version": "1.1.1"
 }


### PR DESCRIPTION
## Summary
- run `scripts/release/semver-bump.sh patch` to move the workspace and internal crates to 1.1.1
- align npm metadata by setting `package.json`/`package-lock.json` to 1.1.1 for the wrapper package
- refresh `Cargo.lock` via the release helper so downstream crates pick up the new version pin

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `gt submit --stack --no-interactive`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped application version to 1.1.1 across the workspace for consistency.
  - Aligned internal components to the new patch version to maintain compatibility.
  - No functional or UI changes; this is a maintenance release focused on version alignment.
  - Ensures smoother package management and clearer version tracking for future updates.
  - Users should not expect any behavior changes from this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->