### PR TITLE
docs(cli): document default history limit [BLZ-153]

### DIFF
--- a/crates/blz-cli/src/cli.rs
+++ b/crates/blz-cli/src/cli.rs
@@ -453,7 +453,9 @@ pub enum Commands {
         copy: bool,
     },
 
-    /// Show recent search history and defaults
+    /// Show recent search history and defaults (last 20 entries by default)
+    ///
+    /// Displays the last 20 searches unless `--limit` is provided to override the count.
     History {
         /// Maximum number of entries to display
         #[arg(long, default_value_t = 20)]


### PR DESCRIPTION
## Summary
- clarify the history command help to mention the default 20 item limit
- add an additional sentence highlighting how to override the default with --limit
- reran rustfmt during commit hooks; no behavioural changes besides help text

## Testing
- gt submit --no-interactive (runs clippy_strict + nextest default)

Closes: [BLZ-153](https://linear.app/outfitter/issue/BLZ-153/add-default-limit-to-blz-history-command-description)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the History subcommand help text to state it shows the last 20 entries by default.
  * Explained that the --limit option can be used to change the number of entries displayed.
  * Improved wording for better readability in the command’s usage information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->