### PR TITLE
docs: refresh CLI docs for new get JSON [BLZ-201]

### DIFF
--- a/docs/agents/use-blz.md
+++ b/docs/agents/use-blz.md
@@ -81,6 +81,7 @@ blz get bun:41994-42009 -C 5 --json
 
 # Combine multiple spans into one payload
 blz get bun --lines "41994-42009,42010-42020" --json
+#   └─ In JSON mode this returns `requests[0].ranges[]`; aggregate snippets manually
 
 # Expand to the whole section (and cap the output to 80 lines)
 blz get bun:41994-42009 --context all --max-lines 80 --json
@@ -103,7 +104,11 @@ blz update --all --json      # Refresh everything
 span=$(blz "test runner" --json | jq -r '.results[0] | "\(.alias):\(.lines)"')
 
 # Fetch the content straight into your pipeline
-blz get "$span" --json | jq '.content'
+blz get "$span" --json | jq -r '.requests[0].snippet'
+
+# Multi-range helper: join snippets when `ranges[]` is present
+blz get bun --lines "41994-42009,42010-42020" --json \
+  | jq -r '.requests[0] | .snippet // ((.ranges // []) | map(.snippet) | join("\n\n"))'
 
 # Filter to high-confidence matches
 blz "test reporters" --json | jq '[.results[] | select(.score >= 60)]'


### PR DESCRIPTION
## Summary
- rewrite the `blz get` section of the CLI docs to demonstrate multi-source usage and the `requests[]` payload
- add inline JSON sample plus jq tips that reference `requests[0].snippet`
- update the agent playbook to call the new field names instead of `.content`

## Testing
- `cargo fmt`
- `cargo clippy --workspace --all-targets -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated multi-range request/response behavior for JSON/JSONL outputs (ranges[] per span; top-level snippet/lineStart/lineEnd omitted in multi-range responses).
  * Revised JSON extraction guidance and examples to use per-request .snippet or joined ranges and a raw JSON extraction path.
  * Added examples and retrieval workflow showing multi-span aggregation and inline guidance for manual snippet aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->