### PR TITLE
fix(mcp): resolve path traversal vulnerability in resource URI parsing [BLZ-223]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,6 +366,7 @@ version = "1.2.0"
 dependencies = [
  "anyhow",
  "blz-core",
+ "chrono",
  "directories",
  "rmcp",
  "serde",


### PR DESCRIPTION
Add defense-in-depth sanitization to prevent path traversal attacks
through malicious MCP resource URIs.

**Security Issue**:
The `normalize_alias` function only performed case normalization and
whitespace trimming, allowing potential path traversal attempts like:
- `blz://sources/../../../etc/passwd`
- `blz://sources/foo/bar`
- `blz://sources/../../config`

**Changes**:
1. Enhanced `normalize_alias` to filter all characters except
   alphanumeric, hyphens, and underscores
2. Added empty alias validation in `parse_source_uri` for both
   URI schemes (blz:// and resource://)
3. Comprehensive documentation explaining security rationale

**Attack Mitigation**:
- Path separators (/, \) stripped
- Parent directory references (..) removed
- Special characters filtered
- Empty results after sanitization rejected with clear error

**Testing**:
- 5 new security-focused tests covering:
  - Path traversal attempts
  - Special character filtering
  - Empty alias rejection
  - Backward compatibility
- All 50 tests passing

**Quality**: cargo fmt ✓, cargo test ✓, cargo clippy -D warnings ✓

Fixes: BLZ-223

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>