### PR TITLE
chore: Refactor base branch patterns in .coderabbit.yaml

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -22,9 +22,9 @@ reviews:
       - "main"
       - "fix/.*"
       - "feat/.*"
-      - "gt/.*"      # Graphite stacked branches with slash prefix
-      - "gt-.*"      # Graphite stacked branches with dash prefix
+      - "gt.*"           # Graphite stacked branches with gt prefix
       - ".*-blz-[0-9]+"  # Linear-generated branches like feature-blz-123
+      - "blz-.*"         # Linear-generated branches like blz-123-feature
 
   tools:
     clippy:


### PR DESCRIPTION
This pull request updates branch matching patterns in the `.coderabbit.yaml` configuration to improve support for Graphite and Linear-generated branches. The changes refine how branch names are matched for review workflows.

Branch pattern updates:

* Simplified the Graphite branch matching pattern from separate slash and dash prefixes (`gt/.*`, `gt-.*`) to a single pattern (`gt.*`) to match any branch starting with `gt`.
* Added a new pattern (`blz-.*`) to match Linear-generated branches that start with `blz-`, in addition to the existing pattern for branches containing `-blz-`.