### PR TITLE
feat(search): add headings-only flag [BLZ-228]

### DIFF
--- a/crates/blz-cli/src/cli.rs
+++ b/crates/blz-cli/src/cli.rs
@@ -469,6 +469,9 @@ pub enum Commands {
             display_order = 34
         )]
         max_lines: Option<usize>,
+        /// Restrict matches to heading text only
+        #[arg(long = "headings-only", display_order = 35)]
+        headings_only: bool,
         /// Don't save this search to history
         #[arg(long = "no-history")]
         no_history: bool,

--- a/crates/blz-cli/src/prompts/blz.prompt.json
+++ b/crates/blz-cli/src/prompts/blz.prompt.json
@@ -14,6 +14,7 @@
       "name": "Retrieval loop",
       "steps": [
         "Default: `blz search \"<query>\" -C all --json` to gather ranked spans with full sections ready for prompts.",
+        "Heading anchored: `blz search \"# <exact heading text>\" --headings-only --context all --json` to lock onto stable headings and expand nested content in one call.",
         "Fallback for tight payloads: call `blz search \"<query>\" --json`, capture the alias and lines (e.g. `bun:1853-1858`), then fetch more context as needed.",
         "For multiple spans on the same source use `blz get bun:1853-1858,1900-1905 -C 2 --json` (or combine with other aliases) and merge snippets client-side."
       ]
@@ -56,6 +57,7 @@
   "agent_tips": [
     "Set `BLZ_OUTPUT_FORMAT=json` to avoid sprinkling `--json` across every call.",
     "Default to one-shot search via `blz search \"<query>\" -C all --json`; fall back to manual span stitching only when payload limits demand it.",
+    "Use `--headings-only` (optionally with a leading `#`) when you need stable section anchors that survive line shifts.",
     "Treat aliases as canonical ids (directory names and resolver lookups rely on them).",
     "Surface `checksum` fields in tool outputs so downstream steps can verify span freshness.",
     "Keep spans short (2-5 snippets) and derive broader context by chaining `get` calls instead of dumping whole documents."

--- a/crates/blz-cli/src/prompts/search.prompt.json
+++ b/crates/blz-cli/src/prompts/search.prompt.json
@@ -19,10 +19,12 @@
     "Terms separated by spaces are OR'd (match any term by default).",
     "Exact phrase: wrap in double quotes, escape with single quotes: `blz '\"background fetch\"'`.",
     "Require terms: prefix with `+` for AND logic: `blz '+api +key rotation'` (requires 'api' AND 'key', 'rotation' optional).",
-    "Scores are BM25\u2014higher scores indicate stronger matches."
+    "Scores are BM25\u2014higher scores indicate stronger matches.",
+    "Prefix the query with '#' to boost heading matches; combine with --headings-only for heading-centric searches."
   ],
   "workflow_for_agents": [
     "Ensure output is JSON (set `BLZ_OUTPUT_FORMAT=json`).",
+    "Heading-focused retrieval: `blz search \"# <exact heading text>\" --headings-only --context all --json` locks onto stable headings before expanding nested content.",
     "One-shot retrieval (recommended): Use `blz search \"<query>\" -C all --json` to get full sections immediately.",
     "Two-step approach (precise control): Select the top hit's alias and lines string (example: `react:220-228`), then fetch with `blz get react:220-228 -C 3 --text`.",
     "When multiple spans from the same alias are needed, call `blz get react:220-228,260-264 -C 2 --json`.",
@@ -36,6 +38,10 @@
     {
       "flag": "--top <percent>",
       "impact": "Keep only top percentile of hits (post-pagination) to reduce noise."
+    },
+    {
+      "flag": "--headings-only",
+      "impact": "Restrict search to heading fields. Pair with the `#` prefix or `--context all` when you want whole sections anchored to specific headings."
     },
     {
       "flag": "--show <components>",
@@ -79,6 +85,10 @@
     {
       "command": "blz \"hooks\" --top 10 --json",
       "why": "Keep only top 10% of results to eliminate noise from weak matches."
+    },
+    {
+      "command": "blz \"# Skip tests with the Bun test runner\" --headings-only --context all --json",
+      "why": "Heading-anchored section retrieval in one call\u2014resilient to line shifts and perfect for follow-up `blz get`."
     }
   ]
 }

--- a/crates/blz-cli/src/utils/history_log.rs
+++ b/crates/blz-cli/src/utils/history_log.rs
@@ -223,6 +223,7 @@ mod tests {
             limit: Some(10),
             total_pages: Some(1),
             total_results: Some(5),
+            headings_only: false,
         }
     }
 

--- a/crates/blz-cli/src/utils/preferences.rs
+++ b/crates/blz-cli/src/utils/preferences.rs
@@ -40,6 +40,8 @@ pub struct SearchHistoryEntry {
     pub total_pages: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_results: Option<usize>,
+    #[serde(default)]
+    pub headings_only: bool,
 }
 
 const fn default_precision() -> u8 {
@@ -136,6 +138,7 @@ pub struct HistoryEntryBuilder<'a> {
     snippet_lines: u8,
     score_precision: u8,
     pagination: PaginationInfo,
+    headings_only: bool,
 }
 
 /// Pagination information for search history
@@ -162,6 +165,7 @@ impl<'a> HistoryEntryBuilder<'a> {
             snippet_lines: default_snippet(),
             score_precision: default_precision(),
             pagination: PaginationInfo::default(),
+            headings_only: false,
         }
     }
 
@@ -180,6 +184,11 @@ impl<'a> HistoryEntryBuilder<'a> {
         self
     }
 
+    pub const fn with_headings_only(mut self, headings_only: bool) -> Self {
+        self.headings_only = headings_only;
+        self
+    }
+
     pub fn build(self) -> SearchHistoryEntry {
         let timestamp = Utc::now().to_rfc3339();
         SearchHistoryEntry {
@@ -194,6 +203,7 @@ impl<'a> HistoryEntryBuilder<'a> {
             limit: self.pagination.limit,
             total_pages: self.pagination.total_pages,
             total_results: self.pagination.total_results,
+            headings_only: self.headings_only,
         }
     }
 }

--- a/crates/blz-core/src/types.rs
+++ b/crates/blz-core/src/types.rs
@@ -26,6 +26,8 @@
 //!
 //! let toc_entry = TocEntry {
 //!     heading_path: vec!["Getting Started".to_string(), "Installation".to_string()],
+//!     heading_path_display: None,
+//!     heading_path_normalized: None,
 //!     lines: "15-42".to_string(),
 //!     anchor: None,
 //!     children: vec![],
@@ -45,6 +47,7 @@
 //!     source: "react".to_string(),
 //!     file: "hooks.md".to_string(),
 //!     heading_path: vec!["Hooks".to_string(), "useState".to_string()],
+//!     raw_heading_path: None,
 //!     lines: "120-145".to_string(),
 //!     line_numbers: Some(vec![120, 145]),
 //!     snippet: "useState returns an array with two elements...".to_string(),

--- a/docs/agents/use-blz.md
+++ b/docs/agents/use-blz.md
@@ -14,9 +14,10 @@ Use the [`blz`](https://github.com/outfitter-dev/blz) CLI to keep documentation 
 4. Prefer `--json` / `--jsonl` outputs so tooling can parse them cleanly
 5. Feed `alias:lines` citations straight into `blz get`
 6. Use `--context all` (plus `--max-lines <N>` if needed) for whole sections, or `-C <N>` to add a small context window
-7. Expect tight payloads: the standard `search` → `get` flow typically returns 20–80 lines instead of multi-kilobyte pages, keeping token usage low
-8. Set a default format when you want every command in JSON: `export BLZ_OUTPUT_FORMAT=json`
-9. Check source health with `blz info <alias> --json` (or `blz list --status --json`) before a heavy retrieval session
+7. Pair `--headings-only` with full-heading queries (optionally prefixed with `#`) to target section titles explicitly before expanding with `--context all`
+8. Expect tight payloads: the standard `search` → `get` flow typically returns 20–80 lines instead of multi-kilobyte pages, keeping token usage low
+9. Set a default format when you want every command in JSON: `export BLZ_OUTPUT_FORMAT=json`
+10. Check source health with `blz info <alias> --json` (or `blz list --status --json`) before a heavy retrieval session
 
 ### Choosing llms.txt vs llms-full.txt
 
@@ -48,6 +49,9 @@ blz "test reporters" --json
 # Control snippet length (default: 200 chars, range: 50-1000)
 blz "api documentation" --max-chars 300 --json  # Longer snippets for better context
 blz "quick reference" --max-chars 100 --json     # Shorter snippets to save tokens
+
+# Target headings explicitly, then expand the full section
+blz "Skip tests with the Bun test runner" --headings-only --context all --max-lines 120 --json
 ```
 
 ### Tuning Snippet Length

--- a/docs/llms/blz/llms-full.txt
+++ b/docs/llms/blz/llms-full.txt
@@ -38,7 +38,7 @@
 ### Targeted Search
 - `blz search "edge cache" --source cloudflare`
 - `--source` (or `-s`) accepts multiple aliases; comma separation is optional.
-- Add `--json` for automation-friendly output.
+- Add `--format json` for automation-friendly output.
 ### Training Queries Against Bundled Docs
 - `blz docs search batching` runs a scoped search against the bundled guide only.
 - `blz docs top` shows a curated quick-start summary (no search required).
@@ -47,7 +47,7 @@
 ## Managing Sources
 ### Listing
 - `blz list --format text` prints status, line counts, last update, and tags.
-- Use `--json` to capture metadata for automations.
+- Use `--format json` to capture metadata for automations.
 ### Adding & Updating
 - `blz add <alias> <url>` resolves llms-full vs llms.txt automatically.
 - `blz update <alias>` refreshes a single cache; `--all` fans out sequentially.
@@ -76,8 +76,8 @@
 
 ## JSON + Agent Workflows
 ### Machine-Readable Docs
-- `blz docs export --json` mirrors the Clap command tree for tool scaffolding.
-- `blz get <alias> section --json` surfaces `requests[]` entries with `snippet`, `lineStart`, and `lineEnd` (multi-range calls expose `ranges[]`).
+- `blz docs export --format json` mirrors the Clap command tree for tool scaffolding.
+- `blz get <alias> section --format json` surfaces `requests[]` entries with `snippet`, `lineStart`, and `lineEnd` (multi-range calls expose `ranges[]`).
 ### Prompt Builder Integration
 - Global `--prompt` flag (e.g., `blz --prompt search`) emits JSON describing arguments, outputs, and gotchas.
 - Agents can read `llms.json` for a normalized Table of Contents and anchor metadata.
@@ -86,7 +86,7 @@
 ## Keeping Bundled Docs Fresh
 - Run `blz docs sync` after upgrading BLZ to pull in the latest embedded guide revision.
 - The sync command compares base64 SHA-256 hashes to skip unnecessary reindexing.
-- `blz list --json` surfaces `tags` that include `internal` and `blz` so you can filter quickly.
+- `blz list --format json` surfaces `tags` that include `internal` and `blz` so you can filter quickly.
 
 ## Troubleshooting
 - `blz doctor` scans for common issues (missing indices, unreadable directories, stale manifests).

--- a/docs/mcp/TOOLS.md
+++ b/docs/mcp/TOOLS.md
@@ -113,6 +113,21 @@ snippets, the source is inferred from each citation string.
 **Tip:** To search multiple sources, call the tool repeatedly with different
 `source` values.
 
+#### `headingsOnly` (boolean, optional)
+
+Restrict search matches to heading text. Defaults to `false`.
+
+When set to `true`, the search ignores body content and only considers heading
+paths. Pair with heading-based queries (optionally prefixed with `#`) to create
+stable anchors that survive line shifts. Works with any `contextMode`, and is
+ignored when only retrieving `snippets`.
+
+**Examples:**
+```javascript
+{query: "# Skip tests with the Bun test runner", source: "bun", headingsOnly: true, contextMode: "all"}
+{query: "Deploy on Cloudflare", source: "astro", headingsOnly: true}
+```
+
 #### `contextMode` (enum, optional)
 
 Controls snippet expansion. Default: `"none"`.


### PR DESCRIPTION
## Summary

Implements a `--headings-only` flag for the search command that restricts searches to heading fields only, filtering out body content matches. This makes it easier to discover specific documentation sections by their titles when you know what you're looking for.

## Changes

- **New `search_headings_only()` method** in `SearchIndex`: Uses only heading-related fields (`heading_path`, `heading_path_display`, `heading_path_normalized`) in the query parser
- **Internal search refactoring**: Introduces `SearchMode` enum and `search_internal()` to share logic between combined and headings-only searches
- **CLI integration**: Adds `--headings-only` flag to the search command and pipes it through to the core search logic
- **MCP support**: Exposes `headingsOnly` parameter in the MCP `blz_find` tool
- **Phrase query preservation**: When using `--headings-only` with quoted phrases, the normalized query retains phrase syntax for exact matching
- **Documentation updates**: Documents the flag in `use-blz.md` and MCP `TOOLS.md`

## Test Plan

- Run `blz search "Skip tests" --headings-only` and verify only heading matches appear
- Search with and without quotes to confirm phrase matching behavior
- Verify existing search tests still pass (headings-only is an additive feature)
- Test via MCP: `blz_find` with `"headingsOnly": true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)