### PR TITLE
feat(cli): rename anchors command to toc

### DIFF
--- a/.claude/agents/blz-tester.md
+++ b/.claude/agents/blz-tester.md
@@ -43,7 +43,7 @@ You are an elite CLI testing specialist with deep expertise in comprehensive sof
    - `blz lookup`: Test registry search, format shortcuts, `--limit`
    - `blz registry`: Test registry management commands
    - `blz alias`: Test alias management (add, rm subcommands)
-   - `blz anchor` / `blz anchors`: Test anchor utilities and remap mappings
+   - `blz anchor` / `blz toc`: Test anchor utilities and remap mappings
    - `blz completions`: Test shell completion generation for different shells
    - Any other commands discovered via `--help`
    - Other `--flags` that are typical in CLI tools that an agent might expect to be available

--- a/SHORT_FLAG_AUDIT.md
+++ b/SHORT_FLAG_AUDIT.md
@@ -157,7 +157,7 @@ context: Option<ContextMode>,
    - Update `Anchors` command struct
    - Update `AnchorCommands::List` struct
    - Update `AnchorCommands::Get` struct
-   - Update corresponding handler code in `commands/anchors.rs`
+   - Update corresponding handler code in `commands/toc.rs`
    - Update tests
 
 2. **Fix 2**: Add `-c` to Search context flag

--- a/crates/blz-cli/agent-instructions.txt
+++ b/crates/blz-cli/agent-instructions.txt
@@ -7,7 +7,7 @@ Canonical handle
 - Use "source" as the canonical identifier for a document. Prefer `--source` (or `-s`) and positional SOURCE where available.
 
 Recommended defaults
-- export BLZ_OUTPUT_FORMAT=json   # agent-friendly default across search/list/anchors/docs
+- export BLZ_OUTPUT_FORMAT=json   # agent-friendly default across search/list/toc/docs
 
 Core Commands
 - Add source (non-interactive): blz add <alias> <llms.txt-url> -y
@@ -64,7 +64,7 @@ Notes
 
 Shell completions
 - Static: blz completions <bash|zsh|fish|powershell>
-- Dynamic aliases & anchors (recommended):
+- Dynamic aliases & headings (recommended):
   - Fish: source scripts/blz-dynamic-completions.fish
   - Zsh:  source scripts/blz-dynamic-completions.zsh (after compinit)
   - PS:   . scripts/blz-dynamic-completions.ps1

--- a/crates/blz-cli/src/cli.rs
+++ b/crates/blz-cli/src/cli.rs
@@ -246,15 +246,15 @@ pub enum Commands {
         command: AnchorCommands,
     },
 
-    /// Show anchors for a source or remap mappings
-    #[command(display_order = 54)]
-    Anchors {
+    /// Show table of contents (headings) for a source
+    #[command(display_order = 54, alias = "anchors")]
+    Toc {
         /// Source alias
         alias: String,
         /// Output format
         #[command(flatten)]
         format: FormatArg,
-        /// Show anchors remap mappings if available
+        /// Show anchor remap mappings if available
         #[arg(long)]
         mappings: bool,
     },
@@ -968,17 +968,17 @@ pub enum ShowComponent {
 
 #[derive(Subcommand, Clone, Debug)]
 pub enum AnchorCommands {
-    /// List anchors for a source
+    /// List table-of-contents entries (headings) for a source
     List {
         /// Source alias
         alias: String,
         /// Output format
         #[command(flatten)]
         format: FormatArg,
-        /// Show anchors remap mappings if available
+        /// Show anchor remap mappings if available
         #[arg(long)]
         mappings: bool,
-        /// Maximum number of anchors to display
+        /// Maximum number of headings to display
         #[arg(short = 'n', long, value_name = "COUNT")]
         limit: Option<usize>,
     },

--- a/crates/blz-cli/src/commands/mod.rs
+++ b/crates/blz-cli/src/commands/mod.rs
@@ -5,9 +5,9 @@
 
 mod add;
 mod alias;
-mod anchors;
 mod clear;
 mod completions;
+mod toc;
 // config module removed in v1.0.0-beta.1 - flavor preferences eliminated
 mod create_source;
 mod diff;
@@ -31,10 +31,10 @@ pub use add::{
     execute_manifest as add_manifest,
 };
 pub use alias::{AliasCommand, execute as manage_alias};
-pub use anchors::{execute as show_anchors, get_by_anchor};
 pub use clear::run as clear_cache;
 pub use completions::generate;
 pub use completions::list_supported;
+pub use toc::{execute as show_toc, get_by_anchor};
 // config command removed in v1.0.0-beta.1 - flavor preferences eliminated
 pub use create_source::execute as create_registry_source;
 pub use diff::show as show_diff;

--- a/crates/blz-cli/src/commands/toc.rs
+++ b/crates/blz-cli/src/commands/toc.rs
@@ -21,7 +21,7 @@ pub async fn execute(
     if mappings {
         let path = storage.anchors_map_path(&canonical)?;
         if !path.exists() {
-            println!("No anchors mappings found for '{canonical}'");
+            println!("No anchor remap metadata found for '{canonical}'");
             return Ok(());
         }
         let txt = std::fs::read_to_string(&path)?;
@@ -37,7 +37,7 @@ pub async fn execute(
             },
             OutputFormat::Text => {
                 println!(
-                    "Anchors remap for {} (updated {})\n",
+                    "Anchor remap metadata for {} (updated {})\n",
                     canonical.green(),
                     map.updated_at
                 );
@@ -53,7 +53,9 @@ pub async fn execute(
                 }
             },
             OutputFormat::Raw => {
-                return Err(anyhow!("Raw output is not supported for anchors"));
+                return Err(anyhow!(
+                    "Raw output is not supported for toc listings. Use --format json, jsonl, or text instead."
+                ));
             },
         }
         return Ok(());
@@ -94,19 +96,20 @@ pub async fn execute(
             println!(
                 "{}",
                 serde_json::to_string_pretty(&entries)
-                    .context("Failed to serialize anchors to JSON")?
+                    .context("Failed to serialize table of contents to JSON")?
             );
         },
         OutputFormat::Jsonl => {
             for e in entries {
                 println!(
                     "{}",
-                    serde_json::to_string(&e).context("Failed to serialize anchors to JSONL")?
+                    serde_json::to_string(&e)
+                        .context("Failed to serialize table of contents to JSONL")?
                 );
             }
         },
         OutputFormat::Text => {
-            println!("Anchors for {}\n", canonical.green());
+            println!("Table of contents for {}\n", canonical.green());
             let mut count = 0;
             for e in &llms.toc {
                 if let Some(limit_count) = limit {
@@ -120,7 +123,9 @@ pub async fn execute(
             }
         },
         OutputFormat::Raw => {
-            return Err(anyhow!("Raw output is not supported for anchors"));
+            return Err(anyhow!(
+                "Raw output is not supported for toc listings. Use --format json, jsonl, or text instead."
+            ));
         },
     }
     Ok(())
@@ -226,7 +231,7 @@ pub async fn get_by_anchor(
 
     let Some(entry) = find(&llms.toc, anchor) else {
         println!("Anchor not found for '{anchor}' in '{canonical}'");
-        println!("Hint: run 'blz anchor list {canonical}' to see available anchors");
+        println!("Hint: run 'blz toc {canonical}' to inspect available headings");
         return Ok(());
     };
 
@@ -286,7 +291,9 @@ pub async fn get_by_anchor(
             }
             Ok(())
         },
-        OutputFormat::Raw => Err(anyhow!("Raw output is not supported for anchors")),
+        OutputFormat::Raw => Err(anyhow!(
+            "Raw output is not supported for toc listings. Use --format json, jsonl, or text instead."
+        )),
     }
 }
 

--- a/crates/blz-cli/src/prompt.rs
+++ b/crates/blz-cli/src/prompt.rs
@@ -21,6 +21,7 @@ const STATS_PROMPT: &str = include_str!("prompts/stats.prompt.json");
 const VALIDATE_PROMPT: &str = include_str!("prompts/validate.prompt.json");
 const DOCTOR_PROMPT: &str = include_str!("prompts/doctor.prompt.json");
 const DIFF_PROMPT: &str = include_str!("prompts/diff.prompt.json");
+const TOC_PROMPT: &str = include_str!("prompts/toc.prompt.json");
 
 #[derive(Clone, Copy)]
 pub enum NoteChannel {
@@ -50,6 +51,7 @@ pub fn emit(target: &str, command: Option<&Commands>) -> anyhow::Result<()> {
         "validate" => Some(VALIDATE_PROMPT),
         "doctor" => Some(DOCTOR_PROMPT),
         "diff" => Some(DIFF_PROMPT),
+        "toc" => Some(TOC_PROMPT),
         _ => None,
     };
 
@@ -95,17 +97,23 @@ fn normalize_target(target: &str, command: Option<&Commands>) -> String {
                 Commands::Clear { .. } => "clear".into(),
                 Commands::Diff { .. } => "diff".into(),
                 Commands::Mcp => "mcp".into(),
-                Commands::Anchor { .. } | Commands::Anchors { .. } => "anchor".into(),
+                Commands::Anchor { .. } => "anchor".into(),
+                Commands::Toc { .. } => "toc".into(),
             };
         }
         return "blz".into();
     }
 
-    target
+    let normalized = target
         .trim()
         .trim_matches('"')
         .replace(['/', ':'], ".")
-        .to_ascii_lowercase()
+        .to_ascii_lowercase();
+
+    match normalized.as_str() {
+        "anchors" => "toc".into(),
+        other => other.into(),
+    }
 }
 
 fn available_targets() -> Vec<&'static str> {
@@ -120,6 +128,7 @@ fn available_targets() -> Vec<&'static str> {
         "lookup",
         "docs",
         "history",
+        "toc",
         "anchor",
         "completions",
         "alias",

--- a/crates/blz-cli/src/prompts/completions.prompt.json
+++ b/crates/blz-cli/src/prompts/completions.prompt.json
@@ -12,7 +12,7 @@
     }
   ],
   "agent_tips": [
-    "For dynamic completions (aliases, anchors) consider sourcing the helper scripts in `scripts/blz-*-init` after installing static completions.",
+    "For dynamic completions (aliases, headings via `blz toc`) consider sourcing the helper scripts in `scripts/blz-*-init` after installing static completions.",
     "When automating environment setup, pair this command with `install-dev.sh` or `cargo install` in a bootstrap script."
   ]
 }

--- a/crates/blz-cli/src/prompts/toc.prompt.json
+++ b/crates/blz-cli/src/prompts/toc.prompt.json
@@ -1,0 +1,51 @@
+{
+  "target": "toc",
+  "summary": "Inspect the table of contents (headings) for a cached source, optionally drilling into anchor remap metadata.",
+  "primary_usage": [
+    {
+      "command": "blz toc <alias>",
+      "description": "Pretty-print the heading hierarchy with line ranges and anchors when available."
+    },
+    {
+      "command": "blz toc <alias> --format json",
+      "description": "Machine-readable output suitable for agents; includes raw and normalized heading paths plus anchors."
+    },
+    {
+      "command": "blz toc <alias> --mappings",
+      "description": "Show anchor remap metadata (old/new line spans) captured during updates."
+    }
+  ],
+  "workflow_for_agents": [
+    "Use this before `blz get` to anchor requests to stable headings rather than line numbers.",
+    "Pair with `--format json` to feed heading paths into automatic prompt builders.",
+    "When a section moved between updates, call `--mappings` to translate older anchor references."
+  ],
+  "helpful_flags": [
+    {
+      "flag": "--limit <N>",
+      "impact": "Trim output to the first N headings. Useful while exploring large docs."
+    },
+    {
+      "flag": "--mappings",
+      "impact": "Switch to anchor remap report instead of the live table of contents."
+    },
+    {
+      "flag": "--format <text|json|jsonl>",
+      "impact": "Choose the output style best suited to human review or automation."
+    }
+  ],
+  "try_this": [
+    {
+      "command": "blz toc bun --limit 20",
+      "why": "Quick scan of top-level headings before issuing targeted searches."
+    },
+    {
+      "command": "blz toc bun --format json | jq '.[] | {path: .headingPath, anchor: .anchor}'",
+      "why": "Generate a terse map of headings to anchors for downstream tooling."
+    },
+    {
+      "command": "blz toc react --mappings --format json",
+      "why": "Inspect how section anchors shifted between updates so agents can refresh citations."
+    }
+  ]
+}

--- a/crates/blz-cli/tests/anchor_get.rs
+++ b/crates/blz-cli/tests/anchor_get.rs
@@ -37,11 +37,11 @@ async fn anchor_get_returns_expected_section() -> anyhow::Result<()> {
         .assert()
         .success();
 
-    // Get anchors JSON
+    // Get TOC JSON
     let mut cmd = blz_cmd();
     let anchors_out = cmd
         .env("BLZ_DATA_DIR", tmp.path())
-        .args(["anchors", "e2e", "-f", "json"])
+        .args(["toc", "e2e", "-f", "json"])
         .assert()
         .success()
         .get_output()
@@ -49,7 +49,7 @@ async fn anchor_get_returns_expected_section() -> anyhow::Result<()> {
         .clone();
     let entries: Value = serde_json::from_slice(&anchors_out)?;
     let arr = entries.as_array().cloned().unwrap_or_default();
-    assert!(!arr.is_empty(), "expected anchors list");
+    assert!(!arr.is_empty(), "expected toc list");
     // Find anchor for heading A
     let anchor = arr
         .iter()

--- a/docs/cli/shell_integration.md
+++ b/docs/cli/shell_integration.md
@@ -208,7 +208,7 @@ source /path/to/blz/scripts/blz-dynamic-completions.zsh
 What it adds:
 
 - `--source`/`-s` dynamic values for `blz search` (also supports `--alias` for backward compatibility)
-- Positional alias completion for `blz get`, `blz update`, `blz remove`, `blz anchors`, and `blz anchor list|get`
+- Positional alias completion for `blz get`, `blz update`, `blz remove`, `blz toc`, and `blz anchor list|get`
 - Anchor value completion for `blz anchor get <alias> <anchor>`
 
 It reads from `blz list --json` and merges canonical + metadata aliases. Falls back to the static `_blz` for everything else.
@@ -427,7 +427,7 @@ source /path/to/blz/scripts/blz-dynamic-completions.fish
 Adds:
 
 - `--source`/`-s` dynamic values for `blz search` (also supports `--alias` for backward compatibility)
-- Positional alias completion for `blz get`, `blz update`, `blz remove`, `blz diff`, `blz anchors`
+- Positional alias completion for `blz get`, `blz update`, `blz remove`, `blz diff`, `blz toc`
 - `blz anchor list <alias>` alias completion
 - `blz anchor get <alias> <anchor>` anchor completion (after alias is provided)
 
@@ -617,7 +617,7 @@ For live alias suggestions (canonical + metadata aliases) when typing `blz` comm
 This adds:
 
 - `--source`/`-s` dynamic values for `blz search` (also supports `--alias` for backward compatibility)
-- Positional alias completion for `blz get`, `blz update`, `blz remove`, `blz anchors`, and `blz anchor list|get`
+- Positional alias completion for `blz get`, `blz update`, `blz remove`, `blz toc`, and `blz anchor list|get`
 - Anchor value completion for `blz anchor get <alias> <anchor>`
 
 It reads from `blz list --json` and merges canonical + metadata aliases.

--- a/scripts/blz-dynamic-completions.fish
+++ b/scripts/blz-dynamic-completions.fish
@@ -30,13 +30,13 @@ except Exception:
 " 2>/dev/null
 end
 
-# Complete anchors for a given alias
+# Complete headings/anchors for a given alias
 function __fish_blz_complete_anchors_for_alias
     set -l alias $argv[1]
     if test -z "$alias"
         return
     end
-    blz anchors $alias --format json 2>/dev/null | python3 -c "
+    blz toc $alias --format json 2>/dev/null | python3 -c "
 import json, sys
 try:
     data = json.load(sys.stdin)
@@ -88,8 +88,8 @@ complete -c blz -n "__fish_seen_subcommand_from diff" -xa "(__fish_blz_complete_
 # Complete for remove command
 complete -c blz -n "__fish_seen_subcommand_from remove" -xa "(__fish_blz_complete_aliases)"
 
-# Complete for anchors command
-complete -c blz -n "__fish_seen_subcommand_from anchors" -xa "(__fish_blz_complete_aliases)"
+# Complete for toc command (alias: anchors)
+complete -c blz -n "__fish_seen_subcommand_from toc; or __fish_seen_subcommand_from anchors" -xa "(__fish_blz_complete_aliases)"
 
 # Complete for anchor list|get (nested subcommands)
 complete -c blz -n "__fish_seen_subcommand_from anchor; and __fish_seen_subcommand_from list" -xa "(__fish_blz_complete_aliases)"
@@ -105,4 +105,5 @@ complete -c blz -n "__fish_blz_needs_command" -a get -d "Get exact line ranges"
 complete -c blz -n "__fish_blz_needs_command" -a sources -d "List blzd sources"
 complete -c blz -n "__fish_blz_needs_command" -a update -d "Update sources with ETag"
 complete -c blz -n "__fish_blz_needs_command" -a diff -d "View changes"
+complete -c blz -n "__fish_blz_needs_command" -a toc -d "Show table of contents for a source"
 complete -c blz -n "__fish_blz_needs_command" -a completions -d "Generate shell completions"

--- a/scripts/blz-dynamic-completions.ps1
+++ b/scripts/blz-dynamic-completions.ps1
@@ -1,7 +1,7 @@
 # Dynamic completions for blz (PowerShell)
 %
 # Provides runtime completions for:
-# - Aliases: `search --alias/-s/--source`, positional for `get`, `update`, `remove`, `anchors`, and `anchor list|get`
+# - Aliases: `search --alias/-s/--source`, positional for `get`, `update`, `remove`, `toc`, and `anchor list|get` (alias: `anchors`)
 # - Anchors: `anchor get <alias> <anchor>` values
 #
 # Usage (PowerShell profile):
@@ -37,7 +37,7 @@ function Get-BlzAnchors {
     param([string]$Alias)
     if (-not $Alias) { return @() }
     try {
-        $json = blz anchors $Alias --format json 2>$null | ConvertFrom-Json
+        $json = blz toc $Alias --format json 2>$null | ConvertFrom-Json
     } catch {
         return @()
     }
@@ -78,7 +78,7 @@ Register-ArgumentCompleter -CommandName blz -ScriptBlock {
     }
 
     # Positional alias for common subcommands
-    if (@('get','update','remove','anchors') -contains $sub) {
+    if (@('get','update','remove','toc','anchors') -contains $sub) {
         # tokens: 0=blz 1=sub 2=<alias>
         if ($tokens.Count -le 2) {
             foreach ($a in $aliases) {

--- a/scripts/blz-dynamic-completions.zsh
+++ b/scripts/blz-dynamic-completions.zsh
@@ -35,13 +35,13 @@ PY
 }
 
 # Print anchors for a given alias as newline-separated list by calling
-# `blz anchors <alias> --format json` and extracting the `anchor` field.
+# `blz toc <alias> --format json` and extracting the `anchor` field.
 __blz_anchors_for_alias() {
   local alias="$1"
   if [[ -z "$alias" ]]; then
     return
   fi
-  blz anchors "$alias" --format json 2>/dev/null | python3 - <<'PY' 2>/dev/null
+  blz toc "$alias" --format json 2>/dev/null | python3 - <<'PY' 2>/dev/null
 import json, sys
 try:
   data = json.load(sys.stdin)
@@ -77,7 +77,7 @@ _blz_dynamic() {
   # positional alias for common subcommands
   if (( ret )); then
     case $sub in
-      get|update|remove|anchors)
+      get|update|remove|toc|anchors)
         if (( CURRENT == 3 )); then
           local -a aliases
           aliases=(${(f)$(__blz_aliases)})


### PR DESCRIPTION
## Summary

Renames the `anchors` command to `toc` (table of contents) to better reflect its purpose of displaying documentation headings. The old `anchors` name is preserved as an alias for backward compatibility.

## Changes

- **Command rename**: `blz anchors` → `blz toc` (with `anchors` as an alias)
- **File rename**: `src/commands/anchors.rs` → `src/commands/toc.rs`
- **Updated CLI help**: Command description now says "Show table of contents (headings)" instead of "Show anchors"
- **Backward compatibility**: `blz anchors` still works via the `alias = "anchors"` attribute
- **Documentation updates**: Shell completion scripts, agent instructions, and docs reflect the new name
- **Prompt file**: Added `toc.prompt.json` for AI prompting support
- **Help text refinement**: Updated parameter descriptions to use "headings" terminology

## Test Plan

- Verify `blz toc <alias>` displays the table of contents
- Confirm `blz anchors <alias>` still works (backward compatibility)
- Check `blz --help` shows the `toc` command with proper description
- Verify shell completions work with both `toc` and `anchors`
- Run existing anchor_get tests to ensure functionality unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the user-facing "anchors" subcommand to "toc" while keeping "anchors" as a compatibility alias.

* **New Features**
  * Added a dedicated "toc" prompt/configuration for inspecting table-of-contents and anchor remap metadata.

* **Documentation**
  * Updated all user-facing text, help messages, prompts, tests, and shell completions to use "toc"/"table of contents" and "headings" terminology.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->