### PR TITLE
chore(cli): hide legacy anchor prompt surface

### DIFF
--- a/crates/blz-cli/src/cli.rs
+++ b/crates/blz-cli/src/cli.rs
@@ -239,8 +239,8 @@ pub enum Commands {
         command: Option<DocsCommands>,
     },
 
-    /// Anchor utilities
-    #[command(display_order = 53)]
+    /// Legacy anchor utilities (use `toc` instead)
+    #[command(display_order = 53, hide = true)]
     Anchor {
         #[command(subcommand)]
         command: AnchorCommands,

--- a/crates/blz-cli/src/prompt.rs
+++ b/crates/blz-cli/src/prompt.rs
@@ -97,8 +97,7 @@ fn normalize_target(target: &str, command: Option<&Commands>) -> String {
                 Commands::Clear { .. } => "clear".into(),
                 Commands::Diff { .. } => "diff".into(),
                 Commands::Mcp => "mcp".into(),
-                Commands::Anchor { .. } => "anchor".into(),
-                Commands::Toc { .. } => "toc".into(),
+                Commands::Anchor { .. } | Commands::Toc { .. } => "toc".into(),
             };
         }
         return "blz".into();
@@ -111,7 +110,7 @@ fn normalize_target(target: &str, command: Option<&Commands>) -> String {
         .to_ascii_lowercase();
 
     match normalized.as_str() {
-        "anchors" => "toc".into(),
+        "anchor" | "anchors" => "toc".into(),
         other => other.into(),
     }
 }
@@ -129,7 +128,6 @@ fn available_targets() -> Vec<&'static str> {
         "docs",
         "history",
         "toc",
-        "anchor",
         "completions",
         "alias",
         "registry",


### PR DESCRIPTION
## Summary

Hides the legacy `anchor` command from help output and consolidates prompt handling to use `toc` as the canonical command name. This reduces UI clutter while maintaining backward compatibility for users who still type `blz anchor`.

## Changes

- **Hide `anchor` command**: Adds `hide = true` attribute to the `Anchor` command in CLI definition
- **Update command description**: Changes "Anchor utilities" to "Legacy anchor utilities (use \`toc\` instead)"
- **Prompt normalization**: Merges `Anchor` and `Toc` match arms in `normalize_target()` to always return "toc"
- **Alias handling**: Updates string normalization to map both "anchor" and "anchors" to "toc"
- **Available targets**: Removes "anchor" from the list of prompt targets since "toc" is the canonical name

## Test Plan

- Run `blz --help` and verify `anchor` command is not listed
- Confirm `blz anchor list <alias>` still works (backward compatibility)
- Verify `blz --prompt anchor` resolves to toc prompt
- Check that prompt handling treats anchor and toc identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)