### PR TITLE
feat(cli): add boolean filtering to toc

### DIFF
--- a/crates/blz-cli/src/cli.rs
+++ b/crates/blz-cli/src/cli.rs
@@ -257,6 +257,9 @@ pub enum Commands {
         /// Maximum number of headings to display
         #[arg(short = 'n', long, value_name = "COUNT")]
         limit: Option<usize>,
+        /// Filter headings by boolean expression (use +term for AND, -term for NOT)
+        #[arg(long = "filter", value_name = "EXPR")]
+        filter: Option<String>,
         /// Limit results to headings at or above this level (1-6)
         #[arg(
             long = "max-depth",
@@ -998,6 +1001,9 @@ pub enum AnchorCommands {
             value_parser = clap::value_parser!(u8).range(1..=6)
         )]
         max_depth: Option<u8>,
+        /// Filter headings by boolean expression (use +term for AND, -term for NOT)
+        #[arg(long = "filter", value_name = "EXPR")]
+        filter: Option<String>,
     },
     /// Get content by anchor
     Get {

--- a/crates/blz-cli/src/lib.rs
+++ b/crates/blz-cli/src/lib.rs
@@ -820,6 +820,7 @@ async fn execute_command(
             alias,
             format,
             limit,
+            filter,
             max_depth,
             mappings,
         }) => {
@@ -829,6 +830,7 @@ async fn execute_command(
                 mappings,
                 limit,
                 max_depth.map(usize::from),
+                filter.as_deref(),
             )
             .await?;
         },
@@ -1016,6 +1018,7 @@ async fn handle_anchor(command: AnchorCommands, quiet: bool) -> Result<()> {
             mappings,
             limit,
             max_depth,
+            filter,
         } => {
             commands::show_toc(
                 &alias,
@@ -1023,6 +1026,7 @@ async fn handle_anchor(command: AnchorCommands, quiet: bool) -> Result<()> {
                 mappings,
                 limit,
                 max_depth.map(usize::from),
+                filter.as_deref(),
             )
             .await
         },

--- a/crates/blz-cli/src/prompts/toc.prompt.json
+++ b/crates/blz-cli/src/prompts/toc.prompt.json
@@ -30,6 +30,10 @@
       "impact": "Trim output to the first N headings. Useful while exploring large docs."
     },
     {
+      "flag": "--filter <expr>",
+      "impact": "Search heading paths with search-style boolean snippets (e.g., '+api -deprecated')."
+    },
+    {
       "flag": "--max-depth <1-6>",
       "impact": "Restrict results to headings at or above the specified depth. Great for zooming out to higher-level sections."
     },
@@ -50,6 +54,10 @@
     {
       "command": "blz toc bun --format json | jq '.[] | {path: .headingPath, anchor: .anchor}'",
       "why": "Generate a terse map of headings to anchors for downstream tooling."
+    },
+    {
+      "command": "blz toc react --filter \"+api -deprecated\" --format json",
+      "why": "Fetch headings that mention API while excluding deprecated sections."
     },
     {
       "command": "blz toc react --max-depth 2 --format json",


### PR DESCRIPTION
## Summary

Adds a `--filter` flag to the `toc` command that supports boolean expression filtering of headings using AND, OR, and NOT operators. Users can now filter table of contents entries by keywords in heading text or anchors.

## Changes

- **New `HeadingFilter` struct**: Parses and evaluates boolean filter expressions with `must` (AND), `any` (OR), and `not` (NOT) term lists
- **Filter syntax support**:
  - `+term` or `term AND term` for AND logic (all terms must match)
  - `term OR term` for OR logic (at least one term must match)
  - `-term` or `NOT term` for NOT logic (term must not match)
  - Mixed expressions: `api +rest -deprecated`
- **Tokenization**: `tokenize_filter()` function handles quoted strings, operators, and prefix syntax
- **Integration**: Updates `collect_entries()`, `print_text()`, and `print_text_with_limit()` to check filter matches before including entries
- **Validation**: Prevents combining `--filter` with `--mappings` (incompatible options)
- **Case-insensitive matching**: All filter terms and haystack text are lowercased for comparison
- **Tests**: Comprehensive test coverage for filter parsing, boolean logic, and edge cases

## Test Plan

- Run `blz toc bun --filter "test"` to see only headings containing "test"
- Try `blz toc bun --filter "+skip +test"` for AND logic
- Test NOT: `blz toc bun --filter "-deprecated"`
- Mix operators: `blz toc bun --filter "api OR cli"`
- Verify quoted strings: `blz toc bun --filter '"test runner"'`
- Run new test suite in `anchor_get.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)