### PR TITLE
refactor(cli): rename --mappings to --anchors in toc command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Enhanced features including built-in validators and autocompletion support
   - Zero breaking changes - CLI behavior remains identical for users
   - Affected commands: `blz remove`, `blz lookup`, `blz registry create-source`
+- **Terminology clarity**: Renamed `blz anchors` to `blz toc` for clearer intent (table of contents)
+  - Better alignment with internal types (`LlmsJson.toc`)
+  - Clearer separation: `toc` for document structure, `--anchors` for anchor metadata
+  - Renamed `--mappings` to `--anchors` for better clarity (old flag remains as hidden alias)
+  - Backward compatibility: `blz anchors` and `--mappings` remain as hidden aliases
+  - No breaking changes for existing users
+
+### Added
+- **Table of contents enhancements**: New filtering and navigation controls for `blz toc`
+  - `--limit <N>`: Trim output to first N headings
+  - `--max-depth <1-6>`: Restrict results to headings at or above specified depth
+  - `--filter <expr>`: Search heading paths with boolean expressions (e.g., `+api -deprecated`)
+  - Improved agent workflows for hierarchical document navigation
 
 ## [1.3.0] - 2025-10-18
 

--- a/crates/blz-cli/src/cli.rs
+++ b/crates/blz-cli/src/cli.rs
@@ -267,9 +267,9 @@ pub enum Commands {
             value_parser = clap::value_parser!(u8).range(1..=6)
         )]
         max_depth: Option<u8>,
-        /// Show anchor remap mappings if available
-        #[arg(long)]
-        mappings: bool,
+        /// Show anchor metadata and remap history
+        #[arg(long, alias = "mappings")]
+        anchors: bool,
     },
     /// Add a new source
     #[command(display_order = 1)]
@@ -988,9 +988,9 @@ pub enum AnchorCommands {
         /// Output format
         #[command(flatten)]
         format: FormatArg,
-        /// Show anchor remap mappings if available
-        #[arg(long)]
-        mappings: bool,
+        /// Show anchor metadata and remap history
+        #[arg(long, alias = "mappings")]
+        anchors: bool,
         /// Maximum number of headings to display
         #[arg(short = 'n', long, value_name = "COUNT")]
         limit: Option<usize>,

--- a/crates/blz-cli/src/commands/toc.rs
+++ b/crates/blz-cli/src/commands/toc.rs
@@ -10,7 +10,7 @@ use crate::utils::parsing::{LineRange, parse_line_ranges};
 pub async fn execute(
     alias: &str,
     output: OutputFormat,
-    mappings: bool,
+    anchors: bool,
     limit: Option<usize>,
     max_depth: Option<usize>,
     filter_expr: Option<&str>,
@@ -20,8 +20,8 @@ pub async fn execute(
     let canonical = crate::utils::resolver::resolve_source(&storage, alias)?
         .map_or_else(|| alias.to_string(), |c| c);
 
-    if mappings && filter_expr.is_some() {
-        return Err(anyhow!("--filter cannot be combined with --mappings"));
+    if anchors && filter_expr.is_some() {
+        return Err(anyhow!("--filter cannot be combined with --anchors"));
     }
 
     let filter = filter_expr
@@ -29,7 +29,7 @@ pub async fn execute(
         .transpose()
         .context("Failed to parse filter expression")?;
 
-    if mappings {
+    if anchors {
         let path = storage.anchors_map_path(&canonical)?;
         if !path.exists() {
             println!("No heading remap metadata found for '{canonical}'");

--- a/crates/blz-cli/src/lib.rs
+++ b/crates/blz-cli/src/lib.rs
@@ -822,12 +822,12 @@ async fn execute_command(
             limit,
             filter,
             max_depth,
-            mappings,
+            anchors,
         }) => {
             commands::show_toc(
                 &alias,
                 format.resolve(cli.quiet),
-                mappings,
+                anchors,
                 limit,
                 max_depth.map(usize::from),
                 filter.as_deref(),
@@ -1015,7 +1015,7 @@ async fn handle_anchor(command: AnchorCommands, quiet: bool) -> Result<()> {
         AnchorCommands::List {
             alias,
             format,
-            mappings,
+            anchors,
             limit,
             max_depth,
             filter,
@@ -1023,7 +1023,7 @@ async fn handle_anchor(command: AnchorCommands, quiet: bool) -> Result<()> {
             commands::show_toc(
                 &alias,
                 format.resolve(quiet),
-                mappings,
+                anchors,
                 limit,
                 max_depth.map(usize::from),
                 filter.as_deref(),

--- a/crates/blz-cli/src/prompts/toc.prompt.json
+++ b/crates/blz-cli/src/prompts/toc.prompt.json
@@ -11,8 +11,8 @@
       "description": "Machine-readable output suitable for agents; includes heading levels, raw and normalized paths, plus anchors."
     },
     {
-      "command": "blz toc <alias> --mappings",
-      "description": "Show anchor remap metadata (old/new line spans) captured during updates."
+      "command": "blz toc <alias> --anchors",
+      "description": "Show anchor metadata and remap history (old/new line spans) captured during updates."
     },
     {
       "command": "blz toc <alias> --limit 50 --max-depth 2",
@@ -38,8 +38,8 @@
       "impact": "Restrict results to headings at or above the specified depth. Great for zooming out to higher-level sections."
     },
     {
-      "flag": "--mappings",
-      "impact": "Switch to anchor remap report instead of the live table of contents."
+      "flag": "--anchors",
+      "impact": "Show anchor metadata including remap history when sections move between updates."
     },
     {
       "flag": "--format <text|json|jsonl>",
@@ -64,7 +64,7 @@
       "why": "Capture just the chapter/section headings for structured navigation."
     },
     {
-      "command": "blz toc react --mappings --format json",
+      "command": "blz toc react --anchors --format json",
       "why": "Inspect how section anchors shifted between updates so agents can refresh citations."
     }
   ]

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -599,7 +599,7 @@ blz toc <ALIAS> [OPTIONS]
   - Prefix with `+` (or use `and`) to require a term
   - Prefix with `-`/`!` (or use `not`) to exclude a term
 - `--max-depth <1-6>` – Restrict results to headings at or above the specified level
-- `--mappings` – Show anchor remap metadata captured during updates (ignores other filters)
+- `--anchors` – Show anchor metadata and remap history (ignores other filters)
 
 **Examples:**
 
@@ -614,7 +614,7 @@ blz toc react --filter "+API -deprecated" --format json
 blz toc astro --max-depth 1
 
 # Inspect stored anchor remap metadata
-blz toc bun --mappings --format json
+blz toc bun --anchors --format json
 ```
 
 ## Default Behavior


### PR DESCRIPTION
Improves clarity and consistency:
- --anchors better describes what you're inspecting (anchor metadata)
- --mappings was implementation detail (old→new line mappings)
- Aligns with command name: 'blz toc' shows table of contents,
  'blz toc --anchors' shows anchor information
- Keeps --mappings as hidden alias for backward compatibility

Part of broader toc terminology improvements following anchor→toc rename.