### PR TITLE
feat(core): persist language filter preference per-source [BLZ-263]

### DIFF
--- a/crates/blz-cli/src/commands/add.rs
+++ b/crates/blz-cli/src/commands/add.rs
@@ -467,6 +467,7 @@ async fn fetch_and_index(
         &parse_result,
         &spinner,
         metrics,
+        no_language_filter,
     )?;
 
     spinner.finish_and_clear();
@@ -579,6 +580,7 @@ async fn add_local_source(
         &parse_result,
         &spinner,
         metrics,
+        no_language_filter,
     )?;
 
     spinner.finish_and_clear();
@@ -624,6 +626,7 @@ fn format_size(bytes: usize) -> String {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn finalize_add(
     storage: &Storage,
     alias: &str,
@@ -632,6 +635,7 @@ fn finalize_add(
     parse_result: &blz_core::ParseResult,
     spinner: &ProgressBar,
     metrics: PerformanceMetrics,
+    no_language_filter: bool,
 ) -> Result<blz_core::LlmsJson> {
     spinner.set_message("Saving content...");
     storage.save_llms_txt(alias, &resolved.content)?;
@@ -700,6 +704,7 @@ fn finalize_add(
         npm_aliases: npm_aliases.clone(),
         github_aliases: github_aliases.clone(),
         origin: origin.clone(),
+        filter_non_english: Some(!no_language_filter),
     };
     storage.save_source_metadata(alias, &metadata)?;
 

--- a/crates/blz-cli/src/commands/docs_bundle.rs
+++ b/crates/blz-cli/src/commands/docs_bundle.rs
@@ -151,6 +151,7 @@ fn install(storage: &Storage, metrics: PerformanceMetrics) -> Result<bool> {
         npm_aliases: Vec::new(),
         github_aliases: Vec::new(),
         origin: llms_json.metadata.origin.clone(),
+        filter_non_english: None,
     };
 
     storage

--- a/crates/blz-cli/src/commands/list.rs
+++ b/crates/blz-cli/src/commands/list.rs
@@ -392,6 +392,7 @@ mod tests {
                     url: url.to_string(),
                 }),
             },
+            filter_non_english: None,
         }
     }
 
@@ -407,6 +408,7 @@ mod tests {
             },
             diagnostics: vec![],
             parse_meta: None,
+            filter_stats: None,
         }
     }
 

--- a/crates/blz-cli/src/commands/refresh.rs
+++ b/crates/blz-cli/src/commands/refresh.rs
@@ -196,6 +196,7 @@ where
         npm_aliases: existing_metadata.npm_aliases,
         github_aliases: existing_metadata.github_aliases,
         origin,
+        filter_non_english: existing_metadata.filter_non_english,
     };
     storage.save_metadata(alias, &metadata)?;
 
@@ -561,6 +562,7 @@ mod tests {
                     url: "https://example.com".into(),
                 }),
             },
+            filter_non_english: None,
         }
     }
 

--- a/crates/blz-cli/src/commands/update.rs
+++ b/crates/blz-cli/src/commands/update.rs
@@ -199,6 +199,7 @@ where
         npm_aliases: existing_metadata.npm_aliases,
         github_aliases: existing_metadata.github_aliases,
         origin,
+        filter_non_english: existing_metadata.filter_non_english,
     };
     storage.save_metadata(alias, &metadata)?;
 
@@ -565,6 +566,7 @@ mod tests {
                     url: "https://example.com".into(),
                 }),
             },
+            filter_non_english: None,
         }
     }
 

--- a/crates/blz-cli/src/utils/json_builder.rs
+++ b/crates/blz-cli/src/utils/json_builder.rs
@@ -37,7 +37,9 @@ pub fn build_llms_json(
                     url: url.to_string(),
                 }),
             },
+            filter_non_english: None,
         },
+        filter_stats: None,
         toc: parse_result.toc.clone(),
         files: vec![FileInfo {
             path: file_name.to_string(),

--- a/crates/blz-core/src/storage.rs
+++ b/crates/blz-core/src/storage.rs
@@ -688,6 +688,7 @@ mod tests {
                         url: format!("https://example.com/{source_name}/llms.txt"),
                     }),
                 },
+                filter_non_english: None,
             },
             toc: vec![TocEntry {
                 heading_path: vec!["Getting Started".to_string()],
@@ -707,6 +708,7 @@ mod tests {
             },
             diagnostics: vec![],
             parse_meta: None,
+            filter_stats: None,
         }
     }
 

--- a/crates/blz-mcp/src/tools/find.rs
+++ b/crates/blz-mcp/src/tools/find.rs
@@ -1670,6 +1670,7 @@ Line 12";
                     manifest: None,
                     source_type: None,
                 },
+                filter_non_english: None,
             },
             toc: vec![
                 TocEntry {
@@ -1704,6 +1705,7 @@ Line 12";
             },
             diagnostics: vec![],
             parse_meta: None,
+            filter_stats: None,
         };
 
         let json_str = serde_json::to_string(&llms_json).expect("Failed to serialize JSON");
@@ -1792,6 +1794,7 @@ Line 12";
                     manifest: None,
                     source_type: None,
                 },
+                filter_non_english: None,
             },
             toc: vec![TocEntry {
                 heading_path: vec!["Overflow".to_string()],
@@ -1808,6 +1811,7 @@ Line 12";
             },
             diagnostics: vec![],
             parse_meta: None,
+            filter_stats: None,
         };
 
         let json_str = serde_json::to_string(&llms_json).expect("Failed to serialize JSON");
@@ -1878,6 +1882,7 @@ B line 3
                     manifest: None,
                     source_type: None,
                 },
+                filter_non_english: None,
             },
             toc: vec![
                 TocEntry {
@@ -1904,6 +1909,7 @@ B line 3
             },
             diagnostics: vec![],
             parse_meta: None,
+            filter_stats: None,
         };
 
         let json_str = serde_json::to_string(&llms_json).expect("Failed to serialize JSON");

--- a/crates/blz-mcp/src/tools/sources.rs
+++ b/crates/blz-mcp/src/tools/sources.rs
@@ -323,6 +323,7 @@ pub async fn handle_source_add(
                 manifest: None,
                 source_type: Some(blz_core::SourceType::Remote { url: url.clone() }),
             },
+            filter_non_english: None,
         },
         toc: parse_result.toc.clone(),
         files: vec![blz_core::FileInfo {
@@ -338,6 +339,7 @@ pub async fn handle_source_add(
             parser_version: 1,
             segmentation: "structured".to_string(),
         }),
+        filter_stats: None,
     };
 
     storage


### PR DESCRIPTION
Store filter preference and stats in source metadata for consistency across refreshes.

Changes:
- Add filter_non_english field to Source struct (Option<bool>)
- Add HeadingFilterStats struct for tracking filtering operations
- Add filter_stats to LlmsJson (Option<HeadingFilterStats>)
- Add filter_non_english to DefaultsConfig (defaults to true)
- Add filter_non_english override to IndexConfig (Option<bool>)
- Ensure backward compatibility with existing sources via #[serde(default)]
- Add comprehensive tests for serialization/deserialization
- Update blz-mcp to initialize new fields
- Update blz-cli commands to initialize new fields (add, docs_bundle, refresh, update)
- Update json_builder utility to initialize new fields

Backward Compatibility:
- Existing sources without filter_non_english field default to None
- Existing sources without filter_stats show as None
- All tests pass with 100% backward compatibility

Fixes: BLZ-263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added global language filtering configuration option with backward-compatible default (enabled).
  * Per-source language filtering override capability for granular control.
  * New `--no-language-filter` flag for the add command to skip filtering on demand.
  * Language filtering statistics now tracked and included in metadata.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->