### PR TITLE
fix(cli): apply language filtering in refresh command [BLZ-264]

### DIFF
--- a/crates/blz-cli/src/commands/list.rs
+++ b/crates/blz-cli/src/commands/list.rs
@@ -392,7 +392,7 @@ mod tests {
                     url: url.to_string(),
                 }),
             },
-            filter_non_english: None,
+            filter_non_english: Some(true),
         }
     }
 

--- a/crates/blz-cli/src/commands/update.rs
+++ b/crates/blz-cli/src/commands/update.rs
@@ -566,7 +566,7 @@ mod tests {
                     url: "https://example.com".into(),
                 }),
             },
-            filter_non_english: None,
+            filter_non_english: Some(true),
         }
     }
 


### PR DESCRIPTION
The refresh command was not re-applying language filtering based on stored
preferences, causing inconsistent behavior between initial add and subsequent
refresh operations.

This commit:
- Adds language filter application after parsing in the refresh command
- Respects the filter_non_english preference stored in metadata
- Calculates and stores HeadingFilterStats in llms.json
- Prints filtering statistics when blocks are filtered (unless quiet mode)
- Updates all test fixtures to include new required fields

The filtering logic uses the same hybrid URL-based and text-based detection
approach as the add command, ensuring consistency across operations.

Fixes: BLZ-264

🤖 Generated with Claude Code (https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced language-based filtering of markdown content during refresh operations
  * Added computation and persistence of filtering statistics alongside saved data
  * Extended refresh functionality with quiet mode support for reduced output verbosity

* **Tests**
  * Updated test configurations to reflect filter settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->