### PR TITLE
chore: add .trail/logs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ coverage.json
 *.log
 test_output.txt
 test_output-*.txt
+.trail/logs
 
 # Claude
 !.claude/commands/log


### PR DESCRIPTION
Add .trail/logs directory to gitignore to exclude generated trail logs from version control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git ignore configuration to exclude additional log files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->