### PR TITLE
chore(docs): cleanup refresh rename references [BLZ-271]

### DIFF
--- a/.agents/logs/202512042300-checkpoint-blz-251-quiet-verbose-flags.md
+++ b/.agents/logs/202512042300-checkpoint-blz-251-quiet-verbose-flags.md
@@ -1,0 +1,98 @@
+---
+date: 2024-12-04T23:00:00Z
+branch: blz-251-add-consistent-quiet-verbose-global-flags
+slug: blz-251-quiet-verbose-flags
+type: checkpoint
+status: abandoned
+linear: BLZ-251
+---
+
+# BLZ-251: Consistent Quiet/Verbose Global Flags
+
+## Summary
+
+This branch attempted to add consistent `--quiet` and `--verbose` global flags across all CLI commands. The work was abandoned because:
+
+1. **Build is broken** - Missing dependencies in Cargo.toml that are still referenced in code
+2. **Mixed concerns** - Combined feature work with unrelated large refactors (removing TOC, language filtering)
+3. **Incomplete implementation** - Only ~40% complete
+
+## What Was Being Implemented
+
+### Core Feature: Global `--quiet`/`-q` and `--verbose`/`-v` Flags
+
+**Changes to `cli.rs`:**
+```rust
+#[arg(short = 'v', long, global = true, conflicts_with = "quiet")]
+pub verbose: bool,
+
+/// Suppress informational messages (only show errors)
+#[arg(short = 'q', long, global = true, conflicts_with = "verbose")]
+pub quiet: bool,
+```
+
+### Key Implementation Pattern
+
+The branch introduced `FormatArg::resolve_with_quiet()` in `cli_args.rs`:
+
+```rust
+/// Returns (OutputFormat, canonical_quiet_state)
+pub fn resolve_with_quiet(quiet: bool) -> (OutputFormat, bool) {
+    // Returns both format and final quiet state
+    // Smart TTY detection for piped vs interactive output
+    // Deprecation warning control with BLZ_SUPPRESS_DEPRECATIONS env var
+}
+```
+
+### Commands Updated
+
+- `search.rs`: Added `quiet` parameter to `SearchOptions` struct
+- `update.rs` (now `refresh.rs`): Integrated quiet flag support
+- `lib.rs`: Updated command handlers to use `resolve_with_quiet()`
+
+## Why It Failed
+
+1. **Removed dependencies from Cargo.toml still used in code:**
+   - `html-escape = "0.2"`
+   - `memchr = "2"`
+   - `unicode-normalization = "0.1"`
+   - These are referenced in `crates/blz-core/src/heading.rs`
+
+2. **Large unrelated deletions mixed in:**
+   - Removed entire TOC/anchors command (~2000+ lines)
+   - Removed language filtering code
+   - Removed config management
+   - These should have been separate PRs
+
+3. **Incomplete integration:**
+   - Not all commands respect quiet flag
+   - Verbose flag behavior not fully defined
+   - No tests for new behavior
+
+## Recommendation for Future Implementation
+
+If revisiting this feature:
+
+1. **Start fresh from current `main`**
+2. **Focus ONLY on quiet/verbose flags** - no other changes
+3. **Implement systematically:**
+   - Add global flags to `Cli` struct
+   - Create `resolve_with_quiet()` utility
+   - Update each command one at a time
+   - Add tests for each command's quiet/verbose behavior
+4. **Target ~150-200 LOC** for a focused, reviewable PR
+
+## Files That Would Need Changes
+
+- `crates/blz-cli/src/cli.rs` - Add global flags
+- `crates/blz-cli/src/utils/cli_args.rs` - Add `resolve_with_quiet()`
+- `crates/blz-cli/src/lib.rs` - Plumb quiet flag to command handlers
+- `crates/blz-cli/src/commands/*.rs` - Each command needs quiet support
+
+## Commit Reference
+
+```
+01e94411 feat(cli): standardize quiet and verbose behavior
+```
+
+Branch abandoned: 2024-12-04

--- a/.agents/logs/templates/FEATURE.md
+++ b/.agents/logs/templates/FEATURE.md
@@ -59,14 +59,14 @@ agent: claude
 
 ## Goal
 
-Implement `blz update` command to refresh cached documentation with conditional fetching using ETags.
+Implement `blz refresh` command to refresh cached documentation with conditional fetching using ETags (keep `blz update` as deprecated alias).
 
 ## Requirements
 
 ### Functional
 
-- Update single source: `blz update <alias>`
-- Update all sources: `blz update --all`
+- Refresh single source: `blz refresh <alias>` (deprecated alias: `blz update <alias>`)
+- Refresh all sources: `blz refresh --all` (deprecated alias: `blz update --all`)
 - Show update status and statistics
 - Archive previous version before updating
 - Rebuild search index after update

--- a/.claude/agents/blz-tester.md
+++ b/.claude/agents/blz-tester.md
@@ -32,7 +32,7 @@ You are an elite CLI testing specialist with deep expertise in comprehensive sof
    - `blz list`: Test empty state, populated state, JSON vs text output, `--status`, `--details`, `--limit`
    - `blz search`: Test basic queries, phrase searches, pagination (`--next`, `--previous`, `--last`), source filtering, scoring, `--max-chars`
    - `blz get`: Test line ranges (colon syntax `source:lines`), context flags (`-C`, `-A`, `-B`, `--context all`), invalid ranges
-   - `blz update`: Test single source and `--all` flag
+   - `blz refresh`: Test single source and `--all` flag (cover deprecated `blz update` alias)
    - `blz remove`: Test removal and confirmation flows
    - `blz history`: Test search history retrieval, filtering, pagination
    - `blz info`: Test detailed source information display

--- a/.claude/agents/docs-trailblazer.md
+++ b/.claude/agents/docs-trailblazer.md
@@ -54,7 +54,7 @@ blz get <alias>:<line-range> -c5 --json
 
 # 4. If needed, add new source
 blz add <alias> <url> -y
-blz update <alias> --json
+blz refresh <alias> --json  # deprecated alias: blz update
 ```
 
 ## Finding llms.txt Sources
@@ -149,7 +149,7 @@ Used [MCP server name] because [reason blz couldn't help].
 - **No matches found**: Try alternative search terms, broader queries, or suggest adding a new source
 - **Multiple equally relevant results**: Present top 3-5 with scores, let user choose or retrieve all
 - **Very large sections**: Use `--max-lines` to prevent overwhelming output, suggest -c<N> for precision
-- **Stale documentation**: Check last updated timestamp, suggest `blz update <alias>` if old
+- **Stale documentation**: Check last updated timestamp, suggest `blz refresh <alias>` (deprecated alias: `blz update`) if old
 - **Network errors when adding sources**: Verify URL is accessible, check for llms-full.txt alternative
 
 ## Important Constraints

--- a/crates/blz-cli/AGENTS.md
+++ b/crates/blz-cli/AGENTS.md
@@ -334,8 +334,8 @@ blz search "async rust" --source bun  # Search specific source
 blz add react https://react.dev/llms.txt  # Add new source
 blz remove react                 # Remove source
 blz list                          # List all sources
-blz update                        # Update all sources
-blz update react                  # Update specific source
+blz refresh --all                 # Refresh all sources (deprecated alias: blz update --all)
+blz refresh react                 # Refresh specific source (deprecated alias: blz update react)
 ```
 
 ## Testing CLI Applications

--- a/crates/blz-cli/agent-instructions.txt
+++ b/crates/blz-cli/agent-instructions.txt
@@ -11,7 +11,7 @@ Recommended defaults
 
 Core Commands
 - Add source (non-interactive): blz add <alias> <llms.txt-url> -y
-- Update all sources:           blz update --all
+- Refresh all sources:          blz refresh --all  # deprecated alias: blz update --all
 - List sources (JSON):          blz list --format json
 - CLI docs (Markdown):          blz docs --format markdown
 - CLI docs (JSON):              BLZ_OUTPUT_FORMAT=json blz docs

--- a/crates/blz-cli/bundled-docs/llms-full.txt
+++ b/crates/blz-cli/bundled-docs/llms-full.txt
@@ -50,7 +50,7 @@
 - Use `--format json` to capture metadata for automations.
 ### Adding & Updating
 - `blz add <alias> <url>` resolves llms-full vs llms.txt automatically.
-- `blz update <alias>` refreshes a single cache; `--all` fans out sequentially.
+- `blz refresh <alias>` refreshes a single cache; `--all` fans out sequentially (deprecated alias: `blz update <alias>`).
 - Add `--yes` (alias `-y`) to auto-accept upgrades when llms-full becomes available.
 ### Removing
 - `blz remove <alias>` deletes cache data and descriptor metadata.

--- a/crates/blz-cli/src/commands/add.rs
+++ b/crates/blz-cli/src/commands/add.rs
@@ -358,7 +358,7 @@ async fn fetch_and_index(
     let storage = Storage::new()?;
     if storage.exists(alias) {
         anyhow::bail!(
-            "Source '{alias}' already exists. Use 'blz update {alias}' or choose a different alias."
+            "Source '{alias}' already exists. Use 'blz refresh {alias}' or choose a different alias."
         );
     }
 
@@ -497,7 +497,7 @@ async fn add_local_source(
     let storage = Storage::new()?;
     if storage.exists(alias) {
         anyhow::bail!(
-            "Source '{alias}' already exists. Use 'blz update {alias}' or choose a different alias."
+            "Source '{alias}' already exists. Use 'blz refresh {alias}' or choose a different alias."
         );
     }
 

--- a/crates/blz-cli/src/commands/diff.rs
+++ b/crates/blz-cli/src/commands/diff.rs
@@ -21,7 +21,7 @@ pub async fn show(alias: &str, since: Option<&str>) -> Result<()> {
     let current: LlmsJson = storage.load_llms_json(&canonical)?;
     let Some(prev_path) = find_previous_llms_json(&storage, &canonical, since)? else {
         println!(
-            "No previous snapshot found for '{canonical}'. Run 'blz update' to create history."
+            "No previous snapshot found for '{canonical}'. Run 'blz refresh {canonical}' (deprecated alias: 'blz update {canonical}') to create history."
         );
         return Ok(());
     };

--- a/crates/blz-cli/src/commands/doctor.rs
+++ b/crates/blz-cli/src/commands/doctor.rs
@@ -215,7 +215,7 @@ fn source_health_check(
     let mut recommendations = Vec::new();
     if stale_count > 0 {
         recommendations.push(format!(
-            "Run `blz update --all` to refresh {stale_count} stale sources"
+            "Run `blz refresh --all` (deprecated alias: `blz update --all`) to refresh {stale_count} stale sources"
         ));
     }
     if corrupted_count > 0 {
@@ -298,13 +298,21 @@ async fn apply_fixes(storage: &Storage, report: &mut HealthReport) -> Result<()>
 
     // Fix 1: Update stale sources
     if !report.source_health.stale_sources.is_empty() {
-        println!("  Updating stale sources...");
+        println!("  Refreshing stale sources...");
         let metrics = blz_core::PerformanceMetrics::default();
         for alias in &report.source_health.stale_sources {
-            #[allow(deprecated)]
-            match crate::commands::update::execute(alias, metrics.clone(), true).await {
-                Ok(()) => println!("    ✓ Updated {alias}"),
-                Err(e) => eprintln!("    ✗ Failed to update {alias}: {e}"),
+            match crate::commands::refresh::execute(
+                alias,
+                metrics.clone(),
+                true,
+                false,
+                None,
+                false,
+            )
+            .await
+            {
+                Ok(()) => println!("    ✓ Refreshed {alias}"),
+                Err(e) => eprintln!("    ✗ Failed to refresh {alias}: {e}"),
             }
         }
     }

--- a/crates/blz-cli/src/commands/update.rs
+++ b/crates/blz-cli/src/commands/update.rs
@@ -91,6 +91,7 @@ impl UpdateIndexer for DefaultIndexer {
 }
 
 /// Result summary for an update.
+#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UpdateOutcome {
     Updated {
@@ -231,7 +232,7 @@ fn create_spinner(message: &str) -> ProgressBar {
 
 /// Execute update for a specific source.
 #[deprecated(since = "1.4.0", note = "use refresh::execute instead")]
-#[allow(clippy::too_many_lines)]
+#[allow(dead_code, clippy::too_many_lines)]
 pub async fn execute(alias: &str, metrics: PerformanceMetrics, quiet: bool) -> Result<()> {
     let storage = Storage::new()?;
     let canonical_alias =

--- a/crates/blz-cli/src/prompts/add.prompt.json
+++ b/crates/blz-cli/src/prompts/add.prompt.json
@@ -41,7 +41,7 @@
     "Verify ingestion with `blz list --json | jq '.[] | select(.alias==\"<alias>\")'` before handing off to prompts."
   ],
   "error_recovery": [
-    "Checksum mismatches typically indicate the upstream file changed mid-run. Retry after `blz update <alias>`.",
+    "Checksum mismatches typically indicate the upstream file changed mid-run. Retry after `blz refresh <alias>` (deprecated alias: `blz update <alias>`).",
     "HTTP 404/401 responses surface as user errors—confirm the llms.txt URL is publicly accessible or supply credentials via manifest if supported.",
     "Duplicate alias? Run `blz remove <alias>` first or choose an alternative canonical name."
   ]

--- a/crates/blz-cli/src/prompts/blz.prompt.json
+++ b/crates/blz-cli/src/prompts/blz.prompt.json
@@ -22,7 +22,7 @@
     {
       "name": "Maintenance",
       "steps": [
-        "Schedule `blz update --all` routinely to keep checksums current.",
+        "Schedule `blz refresh --all` routinely to keep checksums current (deprecated alias: `blz update --all`).",
         "Audit staleness via `blz list --json | jq '.[] | select(.stalenessDays > 3)'`.",
         "Use `./hydrate-dev.sh --force` to clone production caches into the `blz-dev` profile when testing."
       ]
@@ -46,8 +46,8 @@
       "purpose": "Source onboarding with non-interactive confirmation."
     },
     {
-      "command": "blz update --all",
-      "purpose": "Refresh caches while honoring HTTP caching headers."
+      "command": "blz refresh --all",
+      "purpose": "Refresh caches while honoring HTTP caching headers (deprecated alias: `blz update --all`)."
     },
     {
       "command": "blz --prompt <target>",

--- a/crates/blz-cli/src/prompts/clear.prompt.json
+++ b/crates/blz-cli/src/prompts/clear.prompt.json
@@ -18,7 +18,7 @@
   ],
   "agent_guidance": [
     "Call `blz list --json` beforehand and persist any metadata you need to restore.",
-    "Immediately follow with manifest-driven `blz add` or `blz update --all` to repopulate key sources.",
+    "Immediately follow with manifest-driven `blz add` or `blz refresh --all` (deprecated alias: `blz update --all`) to repopulate key sources.",
     "Use `./hydrate-dev.sh --force` instead when you only need to clone production data into the dev profile."
   ]
 }

--- a/crates/blz-cli/src/prompts/get.prompt.json
+++ b/crates/blz-cli/src/prompts/get.prompt.json
@@ -50,6 +50,6 @@
 	],
 	"error_handling": [
 		"If a range falls outside the cached document, re-run `blz search` to confirm the alias/lines combination and update the source if necessary.",
-		"If content looks outdated, run `blz update <alias>` before fetching spans again."
+		"If content looks outdated, run `blz refresh <alias>` (deprecated alias: `blz update <alias>`) before fetching spans again."
 	]
 }

--- a/crates/blz-cli/src/prompts/info.prompt.json
+++ b/crates/blz-cli/src/prompts/info.prompt.json
@@ -18,7 +18,7 @@
   ],
   "follow_up": [
     "Combine with `blz stats --json` for a workspace-level view.",
-    "If a source is stale, jump straight to `blz update <alias>`.",
+    "If a source is stale, jump straight to `blz refresh <alias>` (deprecated alias: `blz update <alias>`).",
     "To remove it afterwards, call `blz remove <alias> --yes`."
   ]
 }

--- a/crates/blz-cli/src/prompts/list.prompt.json
+++ b/crates/blz-cli/src/prompts/list.prompt.json
@@ -28,7 +28,7 @@
     "descriptor.meta.displayName \u2013 optional human-friendly label if provided."
   ],
   "follow_up_commands": [
-    "Run `blz update <alias>` for stale entries.",
+    "Run `blz refresh <alias>` (deprecated alias: `blz update <alias>`) for stale entries.",
     "Use `blz remove <alias>` to delete unused caches.",
     "Pair with `blz lookup --prompt` to find additional sources to onboard."
   ]

--- a/crates/blz-cli/src/prompts/refresh.prompt.json
+++ b/crates/blz-cli/src/prompts/refresh.prompt.json
@@ -24,6 +24,7 @@
   "notes": [
     "Refresh operations reuse cached metadata. They do **not** re-add alias/tag descriptors\u2014those remain intact.",
     "If the upstream server returns an error, BLZ preserves the previous cache and reports the failure with actionable context.",
-    "Pair with `blz history --clear-before <DATE>` if you want to prune search history post-refresh."
+    "Pair with `blz history --clear-before <DATE>` if you want to prune search history post-refresh.",
+    "`blz update` remains available as a deprecated alias and will emit a warning when used."
   ]
 }

--- a/crates/blz-cli/src/prompts/validate.prompt.json
+++ b/crates/blz-cli/src/prompts/validate.prompt.json
@@ -17,8 +17,8 @@
     "issues \u2013 array of human-readable warnings (missing files, mismatched checksums, offline URLs)"
   ],
   "agent_workflow": [
-    "Run after `blz update --all` to confirm nothing drifted during ingestion.",
-    "If `checksumMatches` is false, re-index via `blz update <alias>` or re-add the source.",
+    "Run after `blz refresh --all` (deprecated alias: `blz update --all`) to confirm nothing drifted during ingestion.",
+    "If `checksumMatches` is false, re-index via `blz refresh <alias>` (deprecated alias: `blz update <alias>`) or re-add the source.",
     "Surface `issues` back to operators or logs so they can repair failing sources."
   ]
 }

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -265,8 +265,8 @@ blz add bun https://bun.sh/llms.txt  # Add a source
 Use a different alias or update the existing source:
 
 ```bash
-# Update existing source
-blz update bun
+# Refresh existing source
+blz refresh bun  # deprecated alias: blz update bun
 
 # Use a different alias
 blz add bun-docs https://bun.sh/llms.txt

--- a/docs/agents/use-blz.md
+++ b/docs/agents/use-blz.md
@@ -146,9 +146,11 @@ blz toc --all -H 1-2 --json
 ## Keep Sources Fresh
 
 ```bash
-blz update bun --json        # Refresh a single source
-blz update --all --json      # Refresh everything
+blz refresh bun --json       # Refresh a single source
+blz refresh --all --json     # Refresh everything
 ```
+
+> `blz update` still works as a deprecated alias and will emit a warning.
 
 ## Common JSON Pipelines
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -107,9 +107,9 @@ blz "api" --json
 # List all sources
 blz list
 
-# Update sources
-blz update --all
-blz update react
+# Refresh sources
+blz refresh --all
+blz refresh react  # deprecated alias: blz update react
 
 # Remove source
 blz remove react

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -49,7 +49,7 @@ For shell integration, see [Shell Integration](shell_integration.md). For task-o
   - [blz get](#blz-get)
 - [Management Commands](#management-commands)
   - [blz list](#blz-list--blz-sources)
-  - [blz update](#blz-update)
+  - [blz refresh](#blz-refresh)
   - [blz remove](#blz-remove--blz-rm--blz-delete)
 - [Utility Commands](#utility-commands)
   - [blz diff](#blz-diff)
@@ -435,12 +435,14 @@ blz list --json
 blz list --details
 ```
 
-### `blz update`
+### `blz refresh`
 
-Update indexed sources with latest content.
+Refresh indexed sources with the latest content.
+
+> The `blz update` command remains available as a deprecated alias and will emit a warning when used.
 
 ```bash
-blz update [ALIAS] [OPTIONS]
+blz refresh [ALIAS] [OPTIONS]
 ```
 
 **Arguments:**
@@ -454,11 +456,11 @@ blz update [ALIAS] [OPTIONS]
 **Examples:**
 
 ```bash
-# Update specific source
-blz update bun
+# Refresh specific source
+blz refresh bun
 
-# Update all sources
-blz update --all
+# Refresh all sources
+blz refresh --all
 ```
 
 ### `blz remove` / `blz rm` / `blz delete`
@@ -764,7 +766,7 @@ Config discovery order:
 2. **Combine with shell tools** - `blz "test" | grep -i jest`
 3. **JSON output for scripts** - Easy to parse with `jq` or similar tools
 4. **Set up completions** - Tab completion makes the CLI much more productive
-5. **Regular updates** - Run `blz update --all` periodically for fresh docs
+5. **Regular refreshes** - Run `blz refresh --all` periodically for fresh docs (the deprecated `blz update` alias still works)
 
 ### `blz --prompt`
 

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -47,7 +47,7 @@ Configuration is merged from lowest to highest priority:
 
 # Environment variable: BLZ_REFRESH_HOURS=6
 
-# CLI flag: blz update react --refresh-hours 1
+# CLI flag: blz refresh react --refresh-hours 1 (`blz update react --refresh-hours 1` alias is deprecated)
 
 # Actual value used: 1 (CLI flag wins)
 ```
@@ -452,7 +452,7 @@ EOF
 export BLZ_REFRESH_HOURS=6
 
 # CLI flag (highest priority)
-blz update react --refresh-hours 1
+blz refresh react --refresh-hours 1  # deprecated alias: blz update react --refresh-hours 1
 ```
 
 ## CLI State Files

--- a/docs/cli/howto.md
+++ b/docs/cli/howto.md
@@ -169,17 +169,19 @@ blz list --details
 blz list --json
 ```
 
-### I want to update all my sources
+### I want to refresh all my sources
 
 ```bash
-blz update --all
+blz refresh --all
 ```
 
-### I want to update one specific source
+### I want to refresh one specific source
 
 ```bash
-blz update bun
+blz refresh bun
 ```
+
+> `blz update` still works as a deprecated alias and emits a warning.
 
 ### I want to remove a source
 

--- a/docs/cli/quick-reference.md
+++ b/docs/cli/quick-reference.md
@@ -78,11 +78,11 @@ blz list
 # With metadata
 blz list --details
 
-# Update single source
-blz update bun
+# Refresh single source
+blz refresh bun  # deprecated alias: blz update bun
 
-# Update all sources
-blz update --all
+# Refresh all sources
+blz refresh --all  # deprecated alias: blz update --all
 
 # Remove source
 blz remove bun
@@ -137,11 +137,11 @@ blz "test runner" --json | jq -r '.results[0] | "\(.alias):\(.lines)"'
 blz get bun:304-324 -C 5
 ```
 
-### Update All Sources Daily
+### Refresh All Sources Daily
 
 ```bash
 # Add to cron/launchd
-blz update --all
+blz refresh --all  # deprecated alias: blz update --all
 ```
 
 ### Integration with Scripts

--- a/docs/cli/shell_integration.md
+++ b/docs/cli/shell_integration.md
@@ -208,7 +208,7 @@ source /path/to/blz/scripts/blz-dynamic-completions.zsh
 What it adds:
 
 - `--source`/`-s` dynamic values for `blz search` (also supports `--alias` for backward compatibility)
-- Positional alias completion for `blz get`, `blz update`, `blz remove`, `blz toc`, and `blz anchor list|get`
+- Positional alias completion for `blz get`, `blz refresh`, `blz remove`, `blz toc`, and `blz anchor list|get`
 - Anchor value completion for `blz anchor get <alias> <anchor>`
 
 It reads from `blz list --json` and merges canonical + metadata aliases. Falls back to the static `_blz` for everything else.
@@ -248,7 +248,7 @@ alias bs='blz search'
 alias bg='blz get'
 alias ba='blz add'
 alias bl='blz list'
-alias bu='blz update --all'
+alias bu='blz refresh --all'  # deprecated alias: blz update --all
 
 # Search function with fzf
 blz-fzf() {
@@ -346,7 +346,7 @@ Fish completions query your actual indexed sources:
 # Complete with your actual sources
 blz search -s <TAB>     # Shows: anthropic, nextjs, tanstack...
 blz get <TAB>           # Shows available sources
-blz update <TAB>        # Lists sources you can update
+blz refresh <TAB>       # Lists sources you can refresh (`blz update` alias still works)
 blz remove <TAB>        # Shows removable sources
 ```
 
@@ -385,7 +385,7 @@ abbr -a bs 'blz search'
 abbr -a bg 'blz get'
 abbr -a ba 'blz add'
 abbr -a bl 'blz list'
-abbr -a bu 'blz update --all'
+abbr -a bu 'blz refresh --all'  # deprecated alias: blz update --all
 
 # Common searches
 abbr -a bsh 'blz search hooks'
@@ -427,7 +427,7 @@ source /path/to/blz/scripts/blz-dynamic-completions.fish
 Adds:
 
 - `--source`/`-s` dynamic values for `blz search` (also supports `--alias` for backward compatibility)
-- Positional alias completion for `blz get`, `blz update`, `blz remove`, `blz diff`, `blz toc`
+- Positional alias completion for `blz get`, `blz refresh`, `blz remove`, `blz diff`, `blz toc`
 - `blz anchor list <alias>` alias completion
 - `blz anchor get <alias> <anchor>` anchor completion (after alias is provided)
 
@@ -572,7 +572,7 @@ function Blz-Quick {
 
 # Update all sources
 function Blz-UpdateAll {
-    blz update --all
+    blz refresh --all  # deprecated alias: blz update --all
 }
 ```
 
@@ -617,7 +617,7 @@ For live alias suggestions (canonical + metadata aliases) when typing `blz` comm
 This adds:
 
 - `--source`/`-s` dynamic values for `blz search` (also supports `--alias` for backward compatibility)
-- Positional alias completion for `blz get`, `blz update`, `blz remove`, `blz toc`, and `blz anchor list|get`
+- Positional alias completion for `blz get`, `blz refresh`, `blz remove`, `blz toc`, and `blz anchor list|get`
 - Anchor value completion for `blz anchor get <alias> <anchor>`
 
 It reads from `blz list --json` and merges canonical + metadata aliases.

--- a/docs/cli/sources.md
+++ b/docs/cli/sources.md
@@ -95,10 +95,10 @@ Output:
 
 > Note: Update functionality is not yet implemented in the MVP
 
-### Future: Update Single Source
+### Future: Refresh Single Source
 
 ```bash
-blz update bun
+blz refresh bun  # deprecated alias: blz update bun
 ```
 
 This will:
@@ -107,10 +107,10 @@ This will:
 - Skip if unchanged (304 Not Modified)
 - Re-index only if content changed
 
-### Future: Update All Sources
+### Future: Refresh All Sources
 
 ```bash
-blz update --all
+blz refresh --all  # deprecated alias: blz update --all
 ```
 
 Updates all sources efficiently using conditional requests.
@@ -262,8 +262,8 @@ blz add webpack https://webpack.js.org/llms.txt
 Once implemented, update regularly:
 
 ```bash
-# Future: Daily update
-blz update --all
+# Future: Daily refresh
+blz refresh --all  # deprecated alias: blz update --all
 ```
 
 ### 4. Monitor Storage

--- a/docs/cli/troubleshooting.md
+++ b/docs/cli/troubleshooting.md
@@ -97,10 +97,10 @@ blz add example https://example.com/llms.txt
 
 **Solutions**:
 
-1. **Update existing source**:
+1. **Refresh existing source**:
 
 ```bash
-blz update bun
+blz refresh bun  # deprecated alias: blz update bun
 ```
 
 2. **Remove and re-add**:
@@ -379,9 +379,9 @@ blz add bun https://bun.sh/llms.txt
 
 ---
 
-## Update Issues
+## Refresh Issues
 
-### Update says "already up to date" but content is stale
+### Refresh says "already up to date" but content is stale
 
 **Problem**: ETag caching prevents fetch when content changed without ETag update
 
@@ -392,17 +392,17 @@ blz remove bun
 blz add bun https://bun.sh/llms.txt
 ```
 
-### Update fails with network error
+### Refresh fails with network error
 
 **Error**: `Error: Network request failed`
 
 **Solutions**:
 
 1. **Check internet connection**
-2. **Retry update**:
+2. **Retry refresh**:
 
 ```bash
-blz update bun
+blz refresh bun  # deprecated alias: blz update bun
 ```
 
 3. **Check URL still valid**:
@@ -497,11 +497,11 @@ blz list --json | jq '[.[] | .lines] | add'
 
 ```bash
 # Instead of:
-blz update --all
+blz refresh --all  # deprecated alias: blz update --all
 
 # Do one at a time:
 for src in $(blz list --json | jq -r '.[].alias'); do
-  blz update "$src"
+  blz refresh "$src"  # deprecated alias: blz update "$src"
 done
 ```
 
@@ -731,7 +731,7 @@ curl -I <url>
 **Solution**: Retry the operation:
 
 ```bash
-blz update <alias>
+blz refresh <alias>  # deprecated alias: blz update <alias>
 ```
 
 ---

--- a/docs/llms/blz/llms-full.txt
+++ b/docs/llms/blz/llms-full.txt
@@ -50,7 +50,7 @@
 - Use `--format json` to capture metadata for automations.
 ### Adding & Updating
 - `blz add <alias> <url>` resolves llms-full vs llms.txt automatically.
-- `blz update <alias>` refreshes a single cache; `--all` fans out sequentially.
+- `blz refresh <alias>` refreshes a single cache; `--all` fans out sequentially (deprecated alias: `blz update <alias>`).
 - Add `--yes` (alias `-y`) to auto-accept upgrades when llms-full becomes available.
 ### Removing
 - `blz remove <alias>` deletes cache data and descriptor metadata.

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -429,7 +429,7 @@ RUST_LOG=debug blz mcp-server
 blz list
 
 # Reindex if needed
-blz update <source>
+blz refresh <source>  # deprecated alias: blz update <source>
 ```
 
 ### High Latency


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed the primary cache command from `blz update` to `blz refresh`. The legacy `blz update` remains as a deprecated alias and will emit a warning when used.
  * Updated user-facing messages to read “Refreshing…” instead of “Updating…” where applicable.

* **Documentation**
  * Revised CLI docs, help text, prompts, examples, and quickstarts to use `blz refresh`, adding explicit deprecation notes for the old alias.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->