### PR TITLE
chore: fix clippy warnings on main

### DIFF
--- a/crates/blz-cli/src/commands/add.rs
+++ b/crates/blz-cli/src/commands/add.rs
@@ -289,7 +289,7 @@ pub async fn execute_manifest(
             (Some(url), None) => {
                 let request = AddRequest::new(
                     normalized_alias.clone(),
-                    url.to_string(),
+                    url.clone(),
                     descriptor_input.clone(),
                     dry_run,
                     quiet,

--- a/crates/blz-cli/tests/search_pagination.rs
+++ b/crates/blz-cli/tests/search_pagination.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 //! Tests for search pagination edge cases including divide-by-zero prevention
 
 mod common;

--- a/crates/blz-core/src/types.rs
+++ b/crates/blz-core/src/types.rs
@@ -67,21 +67,16 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 /// Which llms.txt variant was successfully resolved and used
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum SourceVariant {
     /// llms-full.txt was found and used
     LlmsFull,
     /// llms.txt was found and used
+    #[default]
     Llms,
     /// Custom URL (neither llms.txt nor llms-full.txt)
     Custom,
-}
-
-impl Default for SourceVariant {
-    fn default() -> Self {
-        Self::Llms
-    }
 }
 
 /// Content type based on line count analysis


### PR DESCRIPTION
- types.rs: use derived Default instead of manual impl
- add.rs: use clone() instead of to_string() for implicit clone
- search_pagination.rs: remove duplicate clippy allow attribute

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code quality improvements and refactoring to enhance maintainability.
  * Removed redundant lint configurations in test suite.
  * Improved type system organization for better code consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->