### PR TITLE
docs(release): archive prerelease notes

### DIFF
--- a/.agents/plans/release-flow/PLAN.md
+++ b/.agents/plans/release-flow/PLAN.md
@@ -1,579 +1,179 @@
-# BLZ Release Flow Migration Plan
-
-**Migration from label-based releases to release-please automation**
-
-## Executive Summary
-
-This plan migrates BLZ from a custom label-driven release system to [release-please](https://github.com/googleapis/release-please), Google's automated release management tool. This addresses the current problems of multiple release entrypoints, tool drift, and reliability edge cases while achieving the goal of fully automated releases.
-
-### Key Benefits
-- ✅ **Single release flow** - eliminates multiple "official" paths
-- ✅ **Fully automated** - no manual version bumping or label management  
-- ✅ **Battle-tested** - used by Google and thousands of open-source projects
-- ✅ **Conventional commits ready** - leverages existing `commitlint` enforcement
-- ✅ **Multi-package coordination** - handles Rust workspace + npm package simultaneously
-- ✅ **Audit trail** - explicit release PRs with generated changelogs
-
-## Current State Analysis
-
-### Existing Release Infrastructure
-
-**Files that will be deprecated/replaced:**
-- `.github/workflows/auto-release.yml` (label-driven automation) → **REMOVE**
-- `scripts/release/semver-bump.sh` (custom semver logic) → **REMOVE** 
-- `crates/blz-release` (custom Rust tooling) → **REMOVE**
-- `justfile` `release-prep` (cargo-release path) → **REMOVE**
-- `docs/development/workflow.md` release sections → **UPDATE**
-
-**Files that will be preserved:**
-- `.github/workflows/publish.yml` (build + publish pipeline) → **INTEGRATE**
-- All publish sub-workflows (`publish-npm.yml`, `publish-crates.yml`, etc.) → **KEEP**
-
-### Current Problems Solved
-1. **Multiple tools conflict** (`cargo-release` vs `blz-release`) → Single tool
-2. **Label reliability issues** → Commit-driven automation  
-3. **Documentation drift** → Self-documenting config
-4. **Manual recovery scenarios** → Standardized error handling
-
-## Migration Strategy
-
-### Phase 1: Setup and Configuration (Days 1-2)
-
-**Goal:** Install release-please alongside existing system without disruption
-
-#### Step 1.1: Create release-please configuration
-
-**File: `.release-please-config.json`**
-```json
-{
-  "bootstrap-sha": "8e63a6d",
-  "release-type": "node", 
-  "packages": {
-    ".": {
-      "release-type": "node",
-      "package-name": "@outfitter/blz",
-      "extra-files": [
-        "Cargo.toml",
-        "Cargo.lock"
-      ]
-    },
-    "crates/blz-core": {
-      "release-type": "rust",
-      "package-name": "blz-core"
-    },
-    "crates/blz-cli": {
-      "release-type": "rust", 
-      "package-name": "blz-cli"
-    },
-    "crates/blz-mcp": {
-      "release-type": "rust",
-      "package-name": "blz-mcp"
-    },
-    "crates/blz-registry-build": {
-      "release-type": "rust",
-      "package-name": "blz-registry-build"
-    },
-    "crates/blz-release": {
-      "release-type": "rust",
-      "package-name": "blz-release"
-    }
-  },
-  "group-pull-request-title-pattern": "chore: release ${version}",
-  "separate-pull-requests": false,
-  "pull-request-title-pattern": "chore: release ${component} ${version}",
-  "pull-request-header": "🤖 Release-please has created this PR to release new versions of the following packages:",
-  "changelog-sections": [
-    {"type": "feat", "section": "Features"},
-    {"type": "fix", "section": "Bug Fixes"},
-    {"type": "chore", "section": "Miscellaneous", "hidden": true},
-    {"type": "docs", "section": "Documentation"},
-    {"type": "style", "section": "Styles", "hidden": true},
-    {"type": "refactor", "section": "Code Refactoring"},
-    {"type": "perf", "section": "Performance Improvements"},
-    {"type": "test", "section": "Tests", "hidden": true},
-    {"type": "build", "section": "Build System", "hidden": true},
-    {"type": "ci", "section": "Continuous Integration", "hidden": true}
-  ]
-}
-```
-
-#### Step 1.2: Initialize version manifest
-
-**File: `.release-please-manifest.json`**
-```json
-{
-  ".": "1.3.0",
-  "crates/blz-core": "1.3.0", 
-  "crates/blz-cli": "1.3.0",
-  "crates/blz-mcp": "1.3.0",
-  "crates/blz-registry-build": "1.3.0",
-  "crates/blz-release": "1.3.0"
-}
-```
-
-**Notes:**
-- Use current version (1.3.0) as starting point
-- release-please will manage this file going forward
-- All packages start synchronized
-
-#### Step 1.3: Create release-please workflow
-
-**File: `.github/workflows/release-please.yml`**
-```yaml
-name: Release Please
-
-on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
-
-permissions:
-  contents: write
-  pull-requests: write
-
-jobs:
-  release-please:
-    runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-      version: ${{ steps.release.outputs.version }}
-      # Package-specific outputs for conditional publishing
-      blz-core--release_created: ${{ steps.release.outputs['crates/blz-core--release_created'] }}
-      blz-cli--release_created: ${{ steps.release.outputs['crates/blz-cli--release_created'] }}
-      blz-mcp--release_created: ${{ steps.release.outputs['crates/blz-mcp--release_created'] }}
-      blz-registry-build--release_created: ${{ steps.release.outputs['crates/blz-registry-build--release_created'] }}
-      blz-release--release_created: ${{ steps.release.outputs['crates/blz-release--release_created'] }}
-      npm--release_created: ${{ steps.release.outputs['--release_created'] }}
-    steps:
-      - name: Release Please
-        uses: google-github-actions/release-please-action@v4
-        id: release
-        with:
-          config-file: .release-please-config.json
-          manifest-file: .release-please-manifest.json
-
-  # Call existing publish workflow when release is created
-  publish:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
-    uses: ./.github/workflows/publish.yml
-    with:
-      tag: ${{ needs.release-please.outputs.tag_name }}
-      mode: 'full'
-      # Skip individual packages if they weren't updated
-      skip_crates: ${{ !needs.release-please.outputs.blz-core--release_created && !needs.release-please.outputs.blz-cli--release_created && !needs.release-please.outputs.blz-mcp--release_created && !needs.release-please.outputs.blz-registry-build--release_created && !needs.release-please.outputs.blz-release--release_created }}
-      skip_npm: ${{ !needs.release-please.outputs.npm--release_created }}
-    secrets: inherit
-```
-
-#### Step 1.4: Test in parallel
-
-**Testing approach:**
-1. Create test commits with conventional commit messages
-2. Verify release-please creates proper PRs (but don't merge yet)
-3. Validate version calculations and changelog generation
-4. Test dry-run mode of publish workflow
-
-**Commands for testing:**
-```bash
-# Create test branch for release-please testing
-git checkout -b test/release-please-migration
-
-# Make test commits
-git commit -m "feat(cli): add test feature for release-please validation" --allow-empty
-git commit -m "fix(core): resolve test issue for release-please validation" --allow-empty
-
-# Push and observe release-please behavior
-git push origin test/release-please-migration
-
-# Manually trigger release-please workflow on test branch
-gh workflow run release-please.yml --ref test/release-please-migration
-```
-
-### Phase 2: Parallel Operation (Days 3-5)
-
-**Goal:** Run both systems simultaneously to validate release-please behavior
-
-#### Step 2.1: Modify auto-release.yml
-
-Add bypass condition to prevent conflicts:
-
-```yaml
-# Add to .github/workflows/auto-release.yml detect job
-- name: Check for release-please override
-  id: override
-  run: |
-    if [[ -f ".release-please-config.json" && "${{ github.event_name }}" == "push" ]]; then
-      echo "skip=true" >> "$GITHUB_OUTPUT"
-      echo "reason=release-please-active" >> "$GITHUB_OUTPUT"
-    fi
-
-# Update bump job condition
-bump:
-  needs: detect
-  if: ${{ github.event_name == 'push' && needs.detect.outputs.skip == 'false' && needs.detect.outputs.override != 'true' }}
-```
-
-#### Step 2.2: Create monitoring workflow
-
-**File: `.github/workflows/release-monitoring.yml`**
-```yaml
-name: Release System Monitor
-
-on:
-  schedule:
-    - cron: '0 12 * * *'  # Daily at noon UTC
-  workflow_dispatch:
-
-jobs:
-  monitor:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Check release system health
-        run: |
-          echo "## Release System Status" >> $GITHUB_STEP_SUMMARY
-          echo "Date: $(date)" >> $GITHUB_STEP_SUMMARY
-          
-          # Check for pending release-please PRs
-          if gh pr list --label "autorelease: pending" --json number,title; then
-            echo "✅ Release-please PRs found" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "ℹ️ No pending release PRs" >> $GITHUB_STEP_SUMMARY
-          fi
-          
-          # Check version consistency
-          CARGO_VERSION=$(awk -F '"' '/^version =/ {print $2; exit}' Cargo.toml)
-          NPM_VERSION=$(jq -r .version package.json)
-          
-          if [[ "$CARGO_VERSION" == "$NPM_VERSION" ]]; then
-            echo "✅ Versions synchronized: $CARGO_VERSION" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "❌ Version mismatch: Cargo=$CARGO_VERSION, npm=$NPM_VERSION" >> $GITHUB_STEP_SUMMARY
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
-
-#### Step 2.3: Validation testing
-
-**Release-please validation:**
-1. Create several test commits with different conventional commit types
-2. Verify release PRs are created correctly  
-3. Test merge of release PR triggers publish workflow
-4. Validate all artifacts are built and published correctly
-
-**Current system validation:**
-1. Verify label-driven releases still work (but with bypass active)
-2. Test edge cases like missing labels, unassociated PRs
-3. Confirm no interference between systems
-
-### Phase 3: Migration Cutover (Day 6)
-
-**Goal:** Switch to release-please as the primary system
-
-#### Step 3.1: Disable old system
-
-**Actions:**
-1. Remove/rename `auto-release.yml` to `auto-release.yml.disabled`
-2. Add deprecation notice to justfile `release-prep` target
-3. Update `.gitignore` to ignore `.semver-meta.json`
-
-#### Step 3.2: Update documentation
-
-**File: `docs/development/workflow.md`**
-- Remove manual release sections
-- Replace with release-please workflow documentation
-- Add conventional commit guidelines
-- Update troubleshooting section
-
-**Key sections to add:**
-```markdown
-## Release Process
-
-Releases are fully automated via [release-please](https://github.com/googleapis/release-please):
-
-1. **Commit with conventional commit format:**
-   ```bash
-   git commit -m "feat(cli): add new search command"
-   git commit -m "fix(core): resolve memory leak in indexer"
-   ```
-
-2. **Release-please analyzes commits and creates release PR**
-3. **Merge release PR to trigger automated publishing**
-
-### Version Bumps
-- `feat:` → minor version bump
-- `fix:` → patch version bump  
-- `feat!:` or `BREAKING CHANGE:` → major version bump
-
-### Manual Override
-If needed, you can manually trigger releases:
-```bash
-gh workflow run release-please.yml
-```
-```
-
-#### Step 3.3: Update contributing guidelines
-
-Add conventional commit enforcement to contribution docs:
-
-```markdown
-## Commit Message Format
-
-We use [Conventional Commits](https://www.conventionalcommits.org/) for automated releases:
-
-```
-<type>[optional scope]: <description>
-
-[optional body]
-
-[optional footer(s)]
-```
-
-**Types:**
-- `feat:` A new feature
-- `fix:` A bug fix
-- `docs:` Documentation changes
-- `style:` Code style changes (formatting, etc.)
-- `refactor:` Code refactoring
-- `perf:` Performance improvements
-- `test:` Adding or modifying tests
-- `chore:` Other changes (dependencies, etc.)
-
-**Breaking changes:**
-Use `feat!:` or `fix!:` or add `BREAKING CHANGE:` in footer.
-```
-
-### Phase 4: Cleanup (Day 7)
-
-**Goal:** Remove deprecated code and finalize migration
-
-#### Step 4.1: Remove deprecated files
-
-```bash
-# Remove old release automation
-rm .github/workflows/auto-release.yml
-rm scripts/release/semver-bump.sh
-rm -rf crates/blz-release
-
-# Update Cargo.toml workspace members
-# Remove blz-release from workspace
-# Note: blz-registry-build remains as it's used for build tooling
-
-# Clean up justfile
-# Remove or update release-prep target
-```
-
-#### Step 4.2: Update dependencies
-
-**File: `Cargo.toml`**
-```toml
-# Remove blz-release from workspace members
-[workspace]
-members = [
-    "crates/blz-core",
-    "crates/blz-cli", 
-    "crates/blz-mcp",
-    "crates/blz-registry-build",  # Keep: used for build tooling
-    # Remove: "crates/blz-release"
-]
-```
-
-#### Step 4.3: Final validation
-
-**Test complete flow:**
-1. Make commits with conventional commit messages
-2. Verify release PR creation
-3. Merge release PR  
-4. Confirm all publish workflows complete successfully
-5. Validate artifacts are published to all registries
-
-## Implementation Timeline
-
-| Day | Phase | Activities | Success Criteria |
-|-----|-------|------------|------------------|
-| 1 | Setup | Create configs, workflows | release-please workflow runs |
-| 2 | Setup | Test parallel operation | Release PR created correctly |
-| 3-4 | Parallel | Monitor both systems | Both systems work independently |
-| 5 | Parallel | Validate integration | Publish workflow triggered by release-please |
-| 6 | Cutover | Switch primary system | release-please is only active system |
-| 7 | Cleanup | Remove deprecated code | Clean repository, docs updated |
-
-## Risk Mitigation
-
-### Risk 1: Release-please misconfiguration
-
-**Likelihood:** Medium  
-**Impact:** High (broken releases)
-
-**Mitigation:**
-- Extensive testing in parallel phase
-- Validate configuration with release-please CLI tool
-- Manual review of first several release PRs
-- Keep old system available as backup during parallel phase
-
-### Risk 2: Conventional commit adoption
-
-**Likelihood:** Low  
-**Impact:** Medium (reduced automation)
-
-**Mitigation:**
-- Already enforcing conventional commits via `commitlint`
-- Update contribution guidelines and docs
-- GitHub commit template with conventional format
-
-### Risk 3: Multi-package version drift  
-
-**Likelihood:** Low  
-**Impact:** Medium (inconsistent versions)
-
-**Mitigation:**
-- Synchronized versioning in configuration
-- Monitoring workflow to detect version mismatches
-- Automated version synchronization in extra-files config
-
-### Risk 4: Integration with existing publish workflow
-
-**Likelihood:** Medium  
-**Impact:** High (publish failures)
-
-**Mitigation:**
-- Minimal changes to existing publish.yml
-- Test integration thoroughly in parallel phase
-- Preserve manual workflow_dispatch triggers as fallback
-
-## Rollback Plan
-
-If critical issues are discovered:
-
-### Immediate Rollback (< 1 hour)
-1. Rename `auto-release.yml.disabled` back to `auto-release.yml`
-2. Disable release-please workflow (add `if: false` condition)
-3. Restore previous system operation
-
-### Full Rollback (< 4 hours)  
-1. Restore deleted files from git history:
-   ```bash
-   git checkout HEAD~n -- .github/workflows/auto-release.yml
-   git checkout HEAD~n -- scripts/release/semver-bump.sh
-   git checkout HEAD~n -- crates/blz-release/
-   ```
-2. Update Cargo.toml workspace members
-3. Restore documentation
-4. Remove release-please files
-
-### Data Recovery
-- Version information preserved in git tags
-- Release history intact in GitHub Releases
-- No data loss risk due to configuration-only changes
-
-## Success Metrics
-
-### Technical Metrics
-- ✅ Single release workflow (1 active system)
-- ✅ Zero manual version bumping
-- ✅ 100% automated changelog generation  
-- ✅ < 5 minute release cycle time (commit → published)
-- ✅ Version synchronization across all packages
-
-### Process Metrics
-- ✅ Zero "why didn't it release?" issues
-- ✅ Reduced release documentation maintenance
-- ✅ Standard GitHub integration (no custom tools)
-- ✅ Clear audit trail (explicit release PRs)
-
-## Post-Migration Optimization
-
-### Phase 5: Enhanced Automation (Optional)
-
-After successful migration, consider these enhancements:
-
-1. **Release notes enhancement:**
-   - Custom release note templates
-   - Automatic breaking change detection
-   - Integration with Linear/GitHub issues
-
-2. **Pre-release automation:**
-   - Canary releases on feature branches
-   - Beta releases for release candidates
-
-3. **Quality gates:**
-   - Block releases if tests fail
-   - Require security audit passing
-   - Performance regression detection
-
-## Appendix A: Configuration Reference
-
-### Conventional Commit Types
-| Type | Version Bump | Description |
-|------|--------------|-------------|
-| `feat` | minor | New feature |
-| `fix` | patch | Bug fix |
-| `perf` | patch | Performance improvement |
-| `refactor` | patch | Code refactoring |
-| `docs` | none | Documentation only |
-| `style` | none | Code style changes |
-| `test` | none | Test changes |
-| `chore` | none | Maintenance |
-| `feat!` | major | Breaking feature |
-| `fix!` | major | Breaking fix |
-
-### Release-please Outputs
-Available in workflow outputs for conditional logic:
-
-```yaml
-# Main release outputs
-release_created: "true"/"false"  
-tag_name: "v1.4.0"
-version: "1.4.0"
-major: "1"
-minor: "4"  
-patch: "0"
-sha: "abc123..."
-upload_url: "https://..."
-
-# Package-specific outputs
-"crates/blz-core--release_created": "true"/"false"
-"crates/blz-cli--release_created": "true"/"false"  
-"--release_created": "true"/"false"  # npm package (root)
-```
-
-## Appendix B: Troubleshooting
-
-### Common Issues
-
-**Issue:** Release-please doesn't create PR
-**Solution:** Check conventional commit format and ensure commits since last release
-
-**Issue:** Wrong version bump calculated  
-**Solution:** Verify conventional commit type matches intended change scope
-
-**Issue:** Multi-package version sync issues
-**Solution:** Check extra-files configuration in .release-please-config.json
-
-**Issue:** Publish workflow not triggered
-**Solution:** Verify workflow_call inputs match release-please outputs
-
-### Debug Commands
-
-```bash
-# Validate release-please config
-npx release-please bootstrap --config-file .release-please-config.json
-
-# Check what release-please would do
-npx release-please --dry-run --config-file .release-please-config.json
-
-# View current manifest state
-cat .release-please-manifest.json
-
-# Check conventional commits since last release
-git log --oneline $(git describe --tags --abbrev=0)..HEAD
-```
-
----
-
-**This plan provides a comprehensive, step-by-step migration from the current label-based system to release-please automation, addressing all identified problems while maintaining the reliability and publish targets of the existing system.**
+# BLZ release flow migration plan (optimized)
+
+Last updated: 2025-12-29
+
+## Executive summary
+
+This plan replaces BLZ's label-based release automation and manual changelog
+maintenance with a single, automated release flow driven by conventional commits.
+We will use release-please to generate a release PR, update `CHANGELOG.md`, and
+create the tag/release, then keep the existing `publish.yml` workflow as the
+publisher of assets and registries. A prerelease branch (`release-canary`) will
+support canary releases. Lockfiles stay up to date via dependency automation,
+not in the release PR.
+
+## Research summary (current state)
+
+### Release entrypoints in the repo today
+- `.github/workflows/auto-release.yml` uses PR labels (`release:*`) to bump and tag versions.
+- `.github/workflows/publish.yml` publishes releases on tag push or manual dispatch.
+- `.github/workflows/release-drafter.yml` creates draft release notes based on labels.
+- `scripts/release/semver-bump.sh` plus `crates/blz-release` compute and sync versions.
+- `justfile` includes `release-prep` using cargo-release.
+
+### Version sources and packaging
+- `package.json` is the npm package source (`@outfitter/blz`).
+- `Cargo.toml` uses a workspace version (`[workspace.package] version = "1.3.0"`).
+- `blz-cli` and `blz-core` use `version.workspace = true`.
+- Workspace dependencies pin `blz-core`/`blz-mcp` versions inside `Cargo.toml`.
+
+### Release history drift
+- Tags show gaps (e.g., `v1.2.0` is missing), while `CHANGELOG.md` lists a 1.2.0 release.
+- GitHub releases show duplicate drafts for `v1.3.1` without a tag.
+- Prior release logs mention manual fixes (e.g., asset gaps and manual semver bumps).
+
+### Changelog and release notes
+- `CHANGELOG.md` is manual and contains a large `Unreleased` section.
+- `publish.yml` generates release notes by walking PRs between tags (not from the changelog).
+- `release-drafter` also generates release notes from labels, creating overlap.
+
+### Summary of pain points
+- Multiple release entrypoints and overlapping release notes.
+- Version drift between tags, releases, and the changelog.
+- Manual steps for versioning and changelog maintenance.
+- Release labels add friction and are easy to miss or misapply.
+
+## Goals
+
+- Single, reliable release path with minimal manual steps.
+- Automated version bumps and changelog updates.
+- Consistent GitHub releases, tags, and registries.
+- Clear canary/prerelease story without extra tooling.
+- Fewer release-specific tools and scripts to maintain.
+
+## Decision: release-please (selected)
+
+### Why release-please
+- GitHub-native and well-suited to a repo that already uses GitHub Actions.
+- Supports conventional commits, which we already enforce.
+- Handles multi-package/version synchronization and changelog updates.
+- Creates release PRs that are easy to review and audit.
+
+### Why not semantic-release (for now)
+- Node-first toolchain adds extra complexity in a Rust-first repo.
+- Would require custom exec plugins to update Cargo workspace versioning.
+- Higher maintenance for cross-language release logic.
+
+## Target release flow (future state)
+
+1. PRs merge to `main` with conventional commits.
+2. release-please opens or updates a single release PR.
+3. Merging the release PR bumps versions and updates `CHANGELOG.md`.
+4. release-please creates the tag and draft GitHub release (notes from changelog).
+5. `publish.yml` uploads assets and publishes to npm, crates.io, and Homebrew.
+6. `publish.yml` publishes the draft release without overwriting release-please notes.
+
+Single entrypoint: release-please is the only system that decides when a release is created.
+
+## Changelog strategy (fix the mess)
+
+- `CHANGELOG.md` is managed by release-please going forward.
+- The former `Unreleased` section is archived in `docs/release/next-release-notes.md`.
+- GitHub release notes should always come from the release-please changelog body.
+
+## Implementation plan
+
+### Phase 0: Preflight and cleanup (1 day)
+
+- Reconcile release state:
+  - Confirm latest tag and release (currently `v1.3.0`).
+  - Close or merge duplicate draft releases (e.g., duplicate `v1.3.1` drafts).
+  - Decide how to handle the missing `v1.2.0` tag (leave as historical drift or backfill if needed).
+- Identify versioned files:
+  - `package.json`
+  - `Cargo.toml` (workspace version + workspace dependency pins)
+- Freeze label-based automation and release-drafter to avoid conflicts during setup.
+
+### Phase 1: Introduce release-please in PR-only mode (1-2 days)
+
+- Add `.release-please-config.json` and `.release-please-manifest.json`.
+- Use a single root package config and update:
+  - `package.json`
+  - `Cargo.toml` workspace version and pinned dependency versions via `extra-files`.
+- Do **not** update lockfiles in release PRs.
+- Configure changelog sections to align with our conventional commit types.
+- Enable `draft: true` so the draft release is ready for publish.yml to attach assets.
+- Run release-please via `workflow_dispatch` only.
+
+Validation checklist:
+- Release PR content (version bumps, changelog entries).
+- Tag format (`vX.Y.Z`) and release draft creation.
+- No asset publishing during dry runs.
+
+### Phase 2: Canary release branch (1 day)
+
+- Create a separate workflow for the `release-canary` branch.
+- Use a dedicated config file (e.g., `.release-please-canary.json`) with:
+  - `prerelease: true`
+  - `prerelease-type: canary`
+  - `draft: true`
+- The canary branch produces prerelease tags and draft releases, published via `publish.yml`.
+
+### Phase 3: Align publish workflow with release-please (1 day)
+
+- Ensure `publish.yml` does not overwrite release-please release notes.
+- Prefer release-please release body; only update notes if explicitly requested.
+- Keep manual `workflow_dispatch` support for one-off re-publish.
+
+### Phase 4: Cutover (same day)
+
+- Enable release-please on `main` and `release-canary`.
+- Disable/remove:
+  - `.github/workflows/auto-release.yml`
+  - `.github/workflows/release-drafter.yml`
+  - `scripts/release/semver-bump.sh`
+  - `crates/blz-release`
+  - `justfile` `release-prep` target
+
+### Phase 5: Documentation updates and guardrails (1 day)
+
+- Update:
+  - `docs/development/ci_cd.md`
+  - `docs/development/workflow.md`
+- Add a short release playbook focused on:
+  - "merge release PR" as the only release action
+  - how to run manual publish if needed
+  - how to cut a canary from `release-canary`
+
+### Phase 6: Lockfile upkeep (same day)
+
+- Fix `.github/dependabot.yml` to keep:
+  - `Cargo.lock` via the `cargo` ecosystem
+  - `package-lock.json` via the `npm` ecosystem
+- Schedule weekly updates; lockfiles stay current outside release PRs.
+
+## Risks and mitigations
+
+- Misconfigured release-please updates the wrong files.
+  - Mitigate with dry runs and explicit file lists.
+- Release notes drift between changelog and GitHub releases.
+  - Mitigate by using release-please body as the single source of truth.
+- Lockfile drift.
+  - Mitigate with Dependabot and periodic dependency updates.
+- Tag creation fails to trigger publish workflows.
+  - Mitigate by using a PAT for release-please (GITHUB_TOKEN does not trigger downstream workflows).
+
+## Rollback plan
+
+- Re-enable `.github/workflows/auto-release.yml`.
+- Restore `scripts/release/semver-bump.sh` and `crates/blz-release`.
+- Revert release-please config and workflow files.
+- Keep `publish.yml` unchanged so tag-based release continues to work.
+
+## Success criteria
+
+- A single release PR is created per release cycle.
+- Version bumps are automated across npm and Rust workspace files.
+- `CHANGELOG.md` is updated automatically and matches GitHub release notes.
+- Tag creation consistently triggers the publish workflow.
+- No manual label application required to ship releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,80 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Breaking Changes
-
-- **MCP Server Command Renamed** ([BLZ-258](https://linear.app/outfitter/issue/BLZ-258)): The command to launch the MCP server has been renamed from `blz mcp` to `blz mcp-server`
-  - This change allows users to add Model Context Protocol documentation as a source using the natural alias `mcp`
-  - **Action Required**: Update MCP server configurations in Claude Code, Cursor, Windsurf, and other AI coding assistants
-  - **Before**: `blz mcp` or `"args": ["mcp"]`
-  - **After**: `blz mcp-server` or `"args": ["mcp-server"]`
-  - Example configuration update:
-    ```json
-    {
-      "mcpServers": {
-        "blz": {
-          "command": "blz",
-          "args": ["mcp-server"]
-        }
-      }
-    }
-    ```
-
-### Added
-- **Claude Code Plugin**: Official plugin for integrating BLZ documentation search into Claude Code workflows
-  - **Commands**: Single `/blz` command handling search, retrieval, and source management
-  - **Agents**: `@blz:blazer` for search, retrieval, and source management workflows
-  - **Skills**: `blz-docs-search` for search patterns, `blz-source-management` for source management
-  - **Dependency Scanning**: Automatic discovery of documentation candidates from Cargo.toml and package.json
-  - **Local Installation**: Support for local development with `/plugin install /path/to/.claude-plugin`
-  - **Documentation**: Comprehensive guides in `docs/agents/claude-code.md` and plugin README
-- **Table of contents enhancements**: New filtering and navigation controls for `blz toc`
-  - `--limit <N>`: Trim output to first N headings
-  - `--max-depth <1-6>`: Restrict results to headings at or above specified depth
-  - `--filter <expr>`: Search heading paths with boolean expressions (e.g., `API AND NOT deprecated`)
-  - Improved agent workflows for hierarchical document navigation
-- **Unified `find` command** ([BLZ-229](https://linear.app/outfitter/issue/BLZ-229)): New command consolidating `search` and `get` with automatic pattern-based dispatch
-  - **Smart routing**: Citations (e.g., `bun:120-142`) trigger retrieve mode; text queries trigger search mode
-  - **Heading-level filtering**: `-H` flag filters results by markdown heading level (1-6)
-    - Single level: `-H 2` (only h2)
-    - Range syntax: `-H 2-4` (h2 through h4)
-    - Comparison: `-H <=2` (h1 and h2)
-    - List: `-H 1,3,5` (specific levels)
-  - **New `level` field**: Search results now include heading level (1-6) for filtering and display
-  - **Configurable defaults**: `BLZ_DEFAULT_LIMIT` environment variable controls default search limit
-  - **Agent prompt**: New `blz --prompt find` provides comprehensive guidance for AI agents
-
-### Changed
-- **CLI prompts migration** ([BLZ-240](https://linear.app/outfitter/issue/BLZ-240)): Replaced `dialoguer` with `inquire` for interactive CLI prompts
-  - Better API ergonomics with cleaner configuration chaining
-  - Improved type safety for prompt handling
-  - Enhanced features including built-in validators and autocompletion support
-  - Zero breaking changes - CLI behavior remains identical for users
-  - Affected commands: `blz remove`, `blz lookup`, `blz registry create-source`
-- **Terminology clarity**: Renamed `blz anchors` to `blz toc` for clearer intent (table of contents)
-  - Better alignment with internal types (`LlmsJson.toc`)
-  - Clearer separation: `toc` for document structure, `--anchors` for anchor metadata
-  - Renamed `--mappings` to `--anchors` for better clarity (old flag remains as hidden alias)
-  - Backward compatibility: `blz anchors` and `--mappings` remain as hidden aliases
-  - No breaking changes for existing users
-- CLI: Rename `update` command to `refresh` ([BLZ-262](https://linear.app/outfitter/issue/BLZ-262))
-- **Plugin Structure**: Consolidated Claude plugin assets under `.claude-plugin/` for clarity
-- **Agent References**: Updated plugin commands to use `@blz:blazer` for unified documentation operations
-
-### Deprecated
-- `blz update` is now hidden and emits a warning. Use `blz refresh` instead.
-- `blz search` and `blz get` are now hidden and emit deprecation warnings. Use `blz find` instead.
-  - Both commands continue to work and route through `find` internally
-  - Will be removed in a future major version
-
-### Fixed
-- **Language filtering consistency** ([BLZ-261](https://linear.app/outfitter/issue/BLZ-261)): Improved locale detection and fallback behavior
-  - Moved default language setting from `Fetcher` to `AddRequest` for consistent application
-  - Consolidated language filter logic to ensure `--no-language-filter` flag properly disables filtering
-  - Added `apply_language_filter` method to centralize URL validation before downloads
-  - Improved test coverage with dedicated language filtering test suite
+Release-please will manage this file after the migration lands. Archived
+pre-cutover notes live in `docs/release/next-release-notes.md`.
 
 ## [1.3.0] - 2025-10-18
 

--- a/docs/release/next-release-notes.md
+++ b/docs/release/next-release-notes.md
@@ -1,0 +1,80 @@
+# Next release notes (pre-cutover)
+
+This file preserves the former `CHANGELOG.md` Unreleased section for the
+release-please migration. Split or merge these notes into the first
+release-please PR as needed.
+
+## Unreleased (archived)
+
+### Breaking Changes
+
+- **MCP Server Command Renamed** ([BLZ-258](https://linear.app/outfitter/issue/BLZ-258)): The command to launch the MCP server has been renamed from `blz mcp` to `blz mcp-server`
+  - This change allows users to add Model Context Protocol documentation as a source using the natural alias `mcp`
+  - **Action Required**: Update MCP server configurations in Claude Code, Cursor, Windsurf, and other AI coding assistants
+  - **Before**: `blz mcp` or `"args": ["mcp"]`
+  - **After**: `blz mcp-server` or `"args": ["mcp-server"]`
+  - Example configuration update:
+    ```json
+    {
+      "mcpServers": {
+        "blz": {
+          "command": "blz",
+          "args": ["mcp-server"]
+        }
+      }
+    }
+    ```
+
+### Added
+- **Claude Code Plugin**: Official plugin for integrating BLZ documentation search into Claude Code workflows
+  - **Commands**: Single `/blz` command handling search, retrieval, and source management
+  - **Agents**: `@blz:blazer` for search, retrieval, and source management workflows
+  - **Skills**: `blz-docs-search` for search patterns, `blz-source-management` for source management
+  - **Dependency Scanning**: Automatic discovery of documentation candidates from Cargo.toml and package.json
+  - **Local Installation**: Support for local development with `/plugin install /path/to/.claude-plugin`
+  - **Documentation**: Comprehensive guides in `docs/agents/claude-code.md` and plugin README
+- **Table of contents enhancements**: New filtering and navigation controls for `blz toc`
+  - `--limit <N>`: Trim output to first N headings
+  - `--max-depth <1-6>`: Restrict results to headings at or above specified depth
+  - `--filter <expr>`: Search heading paths with boolean expressions (e.g., `API AND NOT deprecated`)
+  - Improved agent workflows for hierarchical document navigation
+- **Unified `find` command** ([BLZ-229](https://linear.app/outfitter/issue/BLZ-229)): New command consolidating `search` and `get` with automatic pattern-based dispatch
+  - **Smart routing**: Citations (e.g., `bun:120-142`) trigger retrieve mode; text queries trigger search mode
+- **Heading-level filtering**: `-H` flag filters results by Markdown heading level (1-6)
+    - Single level: `-H 2` (only h2)
+    - Range syntax: `-H 2-4` (h2 through h4)
+    - Comparison: `-H <=2` (h1 and h2)
+    - List: `-H 1,3,5` (specific levels)
+  - **New `level` field**: Search results now include heading level (1-6) for filtering and display
+  - **Configurable defaults**: `BLZ_DEFAULT_LIMIT` environment variable controls default search limit
+  - **Agent prompt**: New `blz --prompt find` provides comprehensive guidance for AI agents
+
+### Changed
+- **CLI prompts migration** ([BLZ-240](https://linear.app/outfitter/issue/BLZ-240)): Replaced `dialoguer` with `inquire` for interactive CLI prompts
+  - Better API ergonomics with cleaner configuration chaining
+  - Improved type safety for prompt handling
+  - Enhanced features including built-in validators and autocompletion support
+  - Zero breaking changes - CLI behavior remains identical for users
+  - Affected commands: `blz remove`, `blz lookup`, `blz registry create-source`
+- **Terminology clarity**: Renamed `blz anchors` to `blz toc` for clearer intent (table of contents)
+  - Better alignment with internal types (`LlmsJson.toc`)
+  - Clearer separation: `toc` for document structure, `--anchors` for anchor metadata
+  - Renamed `--mappings` to `--anchors` for better clarity (old flag remains as hidden alias)
+  - Backward compatibility: `blz anchors` and `--mappings` remain as hidden aliases
+  - No breaking changes for existing users
+- CLI: Rename `update` command to `refresh` ([BLZ-262](https://linear.app/outfitter/issue/BLZ-262))
+- **Plugin Structure**: Consolidated Claude plugin assets under `.claude-plugin/` for clarity
+- **Agent References**: Updated plugin commands to use `@blz:blazer` for unified documentation operations
+
+### Deprecated
+- `blz update` is now hidden and emits a warning. Use `blz refresh` instead.
+- `blz search` and `blz get` are now hidden and emit deprecation warnings. Use `blz find` instead.
+  - Both commands continue to work and route through `find` internally
+  - Will be removed in a future major version
+
+### Fixed
+- **Language filtering consistency** ([BLZ-261](https://linear.app/outfitter/issue/BLZ-261)): Improved locale detection and fallback behavior
+  - Moved default language setting from `Fetcher` to `AddRequest` for consistent application
+  - Consolidated language filter logic to ensure `--no-language-filter` flag properly disables filtering
+  - Added `apply_language_filter` method to centralize URL validation before downloads
+  - Improved test coverage with dedicated language filtering test suite


### PR DESCRIPTION
## Summary
- Archive pre-cutover notes and keep the changelog ready for release-please
- Clarify changelog ownership until the migration lands
- Keep the release-flow plan focused on active steps

## Changes
- Move the former Unreleased notes to `docs/release/next-release-notes.md`
- Update the `CHANGELOG.md` header note to future-tense
- Refresh `.agents/plans/release-flow/PLAN.md` for the migration plan

## Testing
- Not run (docs-only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed MCP server command from `blz mcp` to `blz mcp-server`

* **New Features**
  * Unified find command with smart routing and heading-level filtering
  * Claude Code Plugin support
  * Enhanced table of contents functionality

* **Deprecated**
  * `update`, `search`, and `get` commands now route to modern equivalents with deprecation warnings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->