### PR TITLE
chore(release): guard publish release notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,11 @@ on:
         required: false
         default: false
         type: boolean
+      generate_release_notes:
+        description: 'Generate release notes from PRs (overwrites release body)'
+        required: false
+        default: false
+        type: boolean
       dry_run:
         description: 'Dry run (validate but do not publish)'
         required: false
@@ -75,6 +80,10 @@ on:
         type: boolean
         default: false
       skip_homebrew:
+        required: false
+        type: boolean
+        default: false
+      generate_release_notes:
         required: false
         type: boolean
         default: false
@@ -636,7 +645,12 @@ jobs:
     needs:
       - prepare
       - publish_release
-    if: ${{ always() && needs.publish_release.result == 'success' }}
+    if: >-
+      ${{ always() && needs.publish_release.result == 'success' && (
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+        inputs.generate_release_notes == true ||
+        inputs.generate_release_notes == 'true'
+      ) }}
     runs-on: ubuntu-latest
     outputs:
       body: ${{ steps.notes.outputs.body }}
@@ -770,7 +784,12 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Update release notes
-        if: ${{ needs.release_notes.outputs.body != '' }}
+        if: >-
+          ${{ needs.release_notes.outputs.body != '' && (
+            (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+            inputs.generate_release_notes == true ||
+            inputs.generate_release_notes == 'true'
+          ) }}
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.prepare.outputs.tag }}


### PR DESCRIPTION
## Summary
- Gate release notes generation for manual/call workflows
- Keep tag-push releases generating and updating notes

## Changes
- Add `generate_release_notes` input for `workflow_dispatch`/`workflow_call`
- Allow release notes job and update step on tag push or explicit input

## Testing
- Not run (workflow logic only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added manual trigger option for release notes generation in the publish workflow, allowing release notes to be generated either automatically on tag pushes or explicitly on demand.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->