### PR TITLE
chore(hooks): speed up pre-commit rust checks

### DIFF
--- a/docs/development/git-hooks.md
+++ b/docs/development/git-hooks.md
@@ -19,8 +19,7 @@ Runs automatically before each commit with parallel execution:
 - **Action linting** (`actionlint`) - Validates GitHub Actions syntax
 - **Whitespace checks** - Detects trailing whitespace
 - **Rust formatting** (`cargo fmt`) - Auto-formats Rust code
-- **Quick compile check** (`cargo check`) - Ensures code compiles
-- **Basic clippy** (`cargo clippy --workspace`) - Catches common issues
+- **Rust compile + basic clippy** (`cargo check` + `cargo clippy --workspace`) - Skips when no Rust changes are staged, or only Rust tests/benches/examples change; scopes to `blz-cli` when only `crates/blz-cli/**` changed; emits output to avoid “hang” perception
 
 ### Pre-push Hook (~3 minutes with caching)
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -61,20 +61,49 @@ pre-commit:
         '
       stage_fixed: true
 
-    cargo_check:
-      run: cargo check --workspace --quiet
-
-    clippy_basic:
+    cargo_check_clippy:
       run: |
         bash -lc '
+          CHANGED=$(git diff --name-only --cached -- "*.rs" "**/Cargo.toml" "**/Cargo.lock")
+          NON_TEST_RUST=$(echo "$CHANGED" | grep -Ev '(^crates/.+/tests/|^crates/.+/benches/|^crates/.+/examples/|^crates/.+/testdata/|^tests/|^benches/)' | head -n 1 || true)
+          if [ -z "$CHANGED" ]; then
+            echo "⏭  No Rust changes staged; skipping cargo check + clippy."
+            exit 0
+          fi
+          if [ -z "$NON_TEST_RUST" ]; then
+            echo "⏭  Only test/bench/example Rust changes staged; skipping cargo check + clippy."
+            exit 0
+          fi
           if ! cargo clippy -V >/dev/null 2>&1; then
             echo "clippy not available. Install with: rustup component add clippy"
             echo "Or run: just bootstrap-fast"
             exit 2
           fi
+          if command -v sccache >/dev/null 2>&1; then
+            export RUSTC_WRAPPER=sccache
+            echo "🔧 Using sccache for build acceleration"
+          else
+            echo "💡 Tip: Install sccache for 2-3x faster builds: cargo install sccache"
+          fi
+          SCOPE="workspace"
+          if ! echo "$CHANGED" | grep -Eq "^(Cargo\\.toml|Cargo\\.lock)"; then
+            if ! echo "$CHANGED" | grep -Eqv "^crates/blz-cli/"; then
+              SCOPE="cli"
+            fi
+          fi
+          if [ "$SCOPE" = "cli" ]; then
+            CHECK_ARGS=(-p blz-cli)
+            CLIPPY_ARGS=(-p blz-cli)
+          else
+            CHECK_ARGS=(--workspace)
+            CLIPPY_ARGS=(--workspace)
+          fi
+          echo "🔎 Running cargo check ($SCOPE)..."
+          cargo check "${CHECK_ARGS[@]}"
           # Quick clippy check without full strictness (saves those for pre-push)
           # Only check workspace members, not all targets (no benches, examples)
-          cargo clippy --workspace --quiet -- -W clippy::all
+          echo "🔎 Running clippy (basic, $SCOPE)..."
+          cargo clippy "${CLIPPY_ARGS[@]}" -- -W clippy::all
         '
 
 commit-msg:


### PR DESCRIPTION
## Summary
- Speed up pre-commit Rust checks and reduce perceived hangs
- Scope Rust checks when changes are isolated to `blz-cli`

## Changes
- Combine cargo check + clippy to avoid Cargo lock contention
- Skip Rust checks when no Rust files changed, or only tests/benches/examples changed
- Scope to `-p blz-cli` when only `crates/blz-cli/**` changes are staged
- Enable sccache automatically when available
- Remove quiet flags so output is visible
- Update `docs/development/git-hooks.md`

## Testing
- `lefthook run pre-commit --force` (smoke)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated Rust pre-commit checks into a single combined step for compile + lint.
  * Skips checks when no Rust changes or only tests/benches/examples are staged.
  * Automatically scopes checks to the CLI crate or the full workspace based on changed files.
  * Improves pre-commit feedback (sccache usage hint, missing tooling prompts, and explicit log output to avoid perceived hangs).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->