### PR TITLE
docs: replace deprecated 'blz get' with 'blz find' in documentation

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -56,7 +56,7 @@ All BLZ operations go through a single command. The agent interprets your reques
 /blz list
 
 # Retrieve content by citation
-/blz get bun:304-324
+/blz find bun:304-324
 
 # Refresh documentation sources
 /blz refresh
@@ -118,10 +118,10 @@ Teaches source management:
 /blz "test runner configuration"
 
 # After search returns citation bun:304-324
-/blz get bun:304-324
+/blz find bun:304-324
 
 # Get full section context
-/blz get bun:304-324 --context all
+/blz find bun:304-324 --context all
 ```
 
 ### Keeping documentation fresh

--- a/.claude-plugin/commands/blz.md
+++ b/.claude-plugin/commands/blz.md
@@ -12,7 +12,7 @@ Invoke the `@blz:blazer` agent with this request. The agent handles all BLZ oper
 - **Search**: `/blz "test runner"` or `/blz how do I write tests in Bun`
 - **Add source**: `/blz add bun https://bun.sh/llms-full.txt`
 - **List sources**: `/blz list`
-- **Retrieve content**: `/blz get bun:304-324`
+- **Retrieve content**: `/blz find bun:304-324`
 - **Refresh sources**: `/blz refresh` or `/blz refresh bun`
 - **Complex research**: `/blz Compare React hooks vs Vue composition API`
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -105,7 +105,7 @@ Search results for 'test runner' (6ms):
 Retrieve specific line ranges:
 
 ```bash
-blz get bun:304-324
+blz find bun:304-324
 ```
 
 **You'll see:**
@@ -189,7 +189,7 @@ alias=$(echo "$result" | jq -r '.alias')
 lines=$(echo "$result" | jq -r '.lines')
 
 echo "Found in $alias at lines $lines"
-blz get "$alias:$lines"
+blz find "$alias:$lines"
 ```
 
 ## Shell Completion
@@ -219,7 +219,7 @@ After installation, you can use TAB to complete commands and options:
 ```bash
 blz sea<TAB>        # Completes to: blz search
 blz search --so<TAB> # Completes to: blz search --source
-blz get <TAB>        # Shows available aliases
+blz find <TAB>       # Shows available aliases
 ```
 
 ## Performance Tips

--- a/docs/agents/claude-code.md
+++ b/docs/agents/claude-code.md
@@ -60,14 +60,14 @@ Add a new documentation source to your BLZ index.
 /blz add react https://react.dev/llms.txt
 ```
 
-### `/blz get <citation>`
+### `/blz find <citation>`
 
 Retrieve exact lines from a citation returned by search.
 
 **Examples:**
 ```bash
-/blz get bun:304-324
-/blz get react:2000-2050 -C 5
+/blz find bun:304-324
+/blz find react:2000-2050 -C 5
 ```
 
 ### `/blz list`
@@ -144,7 +144,7 @@ For simple API lookups or single-concept searches:
 /blz "useState hook"
 
 # Retrieve content
-/blz get react:1234-1256
+/blz find react:1234-1256
 ```
 
 ### Complex Research
@@ -206,7 +206,7 @@ The agent will:
 
 4. **Batch retrievals**: Get multiple citations in one call
    ```bash
-   blz get bun:123-456 deno:789-900 react:2000-2050 --json
+   blz find bun:123-456 deno:789-900 react:2000-2050 --json
    ```
 
 ### Source Management

--- a/docs/cli/quick-reference.md
+++ b/docs/cli/quick-reference.md
@@ -54,19 +54,19 @@ blz "query" --page 2
 
 ```bash
 # Colon syntax (preferred, matches search output)
-blz get bun:41994-42009
+blz find bun:41994-42009
 
 # Multiple ranges (comma-separated)
-blz get bun:41994-42009,42010-42020 --json
+blz find bun:41994-42009,42010-42020 --json
 
 # Multiple sources in one call
-blz get bun:41994-42009,42010-42020 turbo:2656-2729 --json
+blz find bun:41994-42009,42010-42020 turbo:2656-2729 --json
 
 # Heading-aware retrieval (entire section, capped at 80 lines)
-blz get bun:41994-42009 --context all --max-lines 80 --json
+blz find bun:41994-42009 --context all --max-lines 80 --json
 
 # Add context lines without blocks
-blz get bun:25760-25780 -C 3
+blz find bun:25760-25780 -C 3
 ```
 
 ### Managing Sources
@@ -134,7 +134,7 @@ blz "test runner" --json | jq -r '.results[0] | "\(.alias):\(.lines)"'
 # Output: bun:304-324
 
 # 2. Get full context
-blz get bun:304-324 -C 5
+blz find bun:304-324 -C 5
 ```
 
 ### Refresh All Sources Daily
@@ -152,7 +152,7 @@ blz refresh --all  # deprecated alias: blz update --all
 result=$(blz "$1" -n1 --json)
 alias=$(echo "$result" | jq -r '.results[0].alias')
 lines=$(echo "$result" | jq -r '.results[0].lines')
-blz get "$alias:$lines"
+blz find "$alias:$lines"
 ```
 
 ## Troubleshooting
@@ -180,7 +180,7 @@ blz --help
 
 # Command-specific help
 blz search --help
-blz get --help
+blz find --help
 
 # Agent integration guidance
 blz --prompt

--- a/docs/cli/search.md
+++ b/docs/cli/search.md
@@ -307,7 +307,7 @@ alias=$(echo "$result" | jq -r '.results[0].alias')
 lines=$(echo "$result" | jq -r '.results[0].lines')
 
 echo "Best match in $alias at lines $lines"
-blz get "$alias:$lines"
+blz find "$alias:$lines"
 ```
 
 ### Search and Open
@@ -324,7 +324,7 @@ if [ "$result" != "null" ]; then
   lines=$(echo "$result" | jq -r '.lines')
 
   echo "Opening $alias at lines $lines..."
-  blz get "$alias:$lines"
+  blz find "$alias:$lines"
 else
   echo "No results found for: $query"
 fi

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -486,7 +486,7 @@ For reference, here's how MCP tools map to CLI commands:
 | MCP Tool | CLI Equivalent |
 |----------|----------------|
 | `find(query=...)` | `blz search "..." --json` |
-| `find(snippets=...)` | `blz get source:lines --json` |
+| `find(snippets=...)` | `blz find source:lines --json` |
 | `list-sources()` | `blz list --json` |
 | `source-add(alias=...)` | `blz add alias url` |
 | `run-command(command="stats")` | `blz stats` |

--- a/docs/mcp/SETUP.md
+++ b/docs/mcp/SETUP.md
@@ -287,7 +287,7 @@ blz list --json
 blz search "test runner" --json
 
 # Get content
-blz get bun:304-324 --json
+blz find bun:304-324 --json
 ```
 
 If these work, the MCP server should work too.

--- a/docs/mcp/TOOLS.md
+++ b/docs/mcp/TOOLS.md
@@ -301,7 +301,7 @@ blz search "test runner" --source bun --json
 **CLI equivalent:**
 
 ```bash
-blz get bun:304-324 --context block --json
+blz find bun:304-324 --context block --json
 ```
 
 #### Example 3: Search and Retrieve
@@ -391,7 +391,7 @@ blz get bun:304-324 --context block --json
 **CLI equivalent:**
 
 ```bash
-blz get bun:100-120,130-150 -C 2 --json
+blz find bun:100-120,130-150 -C 2 --json
 ```
 
 ### Error Handling


### PR DESCRIPTION
## Summary

Replace all occurrences of deprecated `blz get` command with `blz find` across documentation files.

## Changes

| File | Occurrences |
|------|-------------|
| `.claude-plugin/README.md` | 3 |
| `.claude-plugin/commands/blz.md` | 1 |
| `docs/QUICKSTART.md` | 3 |
| `docs/agents/claude-code.md` | 5 |
| `docs/mcp/SETUP.md` | 1 |
| `docs/mcp/README.md` | 1 |
| `docs/mcp/TOOLS.md` | 2 |
| `docs/cli/search.md` | 2 |
| `docs/cli/quick-reference.md` | 4 |

**Total: 22 occurrences replaced**

Files handled by stacked PRs:
- `.claude-plugin/agents/blazer.md` → #366
- `.claude-plugin/skills/blz-docs-search/SKILL.md` → #365

Fixes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command references across documentation files (README, QUICKSTART, CLI reference, and MCP setup guides) from "blz get" to "blz find".
  * Adjusted example commands and usage patterns throughout to reflect the current retrieval command semantics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->