### PR TITLE
fix: hook syntax error and skill MCP documentation

### DIFF
--- a/.claude-plugin/skills/blz-docs-search/SKILL.md
+++ b/.claude-plugin/skills/blz-docs-search/SKILL.md
@@ -13,7 +13,7 @@ Fast local documentation search using blz. Search is local, free, and fast (~6ms
 - Good: `"useEffect cleanup"`, `"test configuration"`, `"HTTP server"`
 - Bad: `"How do I use useEffect?"`, `"What's the best way to..."`
 
-**Citations**: Results include citations like `bun:304-324` (source:start-end lines). Use these with `blz get` to retrieve content.
+**Citations**: Results include citations like `bun:304-324` (source:start-end lines). Use these with `blz find` to retrieve content.
 
 ## Quick Patterns
 
@@ -28,16 +28,16 @@ blz "test runner" --json
 blz "hooks" --source react --json
 
 # Retrieve by citation
-blz get bun:304-324 --json
+blz find bun:304-324 --json
 
 # Retrieve with full section context
-blz get bun:304-324 --context all --json
+blz find bun:304-324 --context all --json
 
 # Retrieve with surrounding lines
-blz get bun:304-324 -C 5 --json
+blz find bun:304-324 -C 5 --json
 
 # Batch retrieve multiple citations
-blz get bun:304-324 deno:500-520 --json
+blz find bun:304-324 deno:500-520 --json
 ```
 
 ## Search Strategy
@@ -68,8 +68,19 @@ blz get bun:304-324 deno:500-520 --json
 ## MCP Alternative
 
 For structured operations, MCP tools are also available:
-```
+```javascript
+// Search documentation
 mcp__blz__blz_find({ query: "test runner" })
+
+// Retrieve citations
 mcp__blz__blz_find({ snippets: ["bun:304-324"] })
+
+// List available sources
 mcp__blz__blz_list_sources()
+
+// Add new source
+mcp__blz__blz_add_source({ alias: "react", url: "https://react.dev/llms.txt" })
+
+// Learn blz usage
+mcp__blz__blz_learn({})
 ```

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -65,7 +65,7 @@ pre-commit:
       run: |
         bash -lc '
           CHANGED=$(git diff --name-only --cached -- "*.rs" "**/Cargo.toml" "**/Cargo.lock")
-          NON_TEST_RUST=$(echo "$CHANGED" | grep -Ev '(^crates/.+/tests/|^crates/.+/benches/|^crates/.+/examples/|^crates/.+/testdata/|^tests/|^benches/)' | head -n 1 || true)
+          NON_TEST_RUST=$(echo "$CHANGED" | grep -Ev "(^crates/.+/tests/|^crates/.+/benches/|^crates/.+/examples/|^crates/.+/testdata/|^tests/|^benches/)" | head -n 1 || true)
           if [ -z "$CHANGED" ]; then
             echo "⏭  No Rust changes staged; skipping cargo check + clippy."
             exit 0


### PR DESCRIPTION
## Summary

Fix shell syntax error in lefthook configuration and update blz-docs-search skill with verified MCP examples.

## Changes

### Hook Fix (`lefthook.yml`)
- Change single quotes to double quotes in grep pattern
- Fixes bash parse error in `cargo_check_clippy` hook

### Skill Updates (`.claude-plugin/skills/blz-docs-search/SKILL.md`)
- Replace deprecated `blz get` with `blz find`
- Add complete MCP tool examples with JavaScript syntax highlighting
- Add missing tools: `blz_add_source`, `blz_learn`
- Verify MCP function names are correct:
  - `mcp__blz__blz_find`
  - `mcp__blz__blz_list_sources`
  - `mcp__blz__blz_add_source`
  - `mcp__blz__blz_learn`

Fixes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced all examples and citation retrieval instructions from "blz get" to "blz find".
  * Updated guidance for citations, full-context and batch retrieval to use the new command.
  * Added a new MCP usage example demonstrating blz_find-related usage.

* **Chores**
  * Adjusted build/config formatting (quoting style updated for a linting hook).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->