### PR TITLE
ci: add path filtering and concurrency to Rust workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,9 +4,27 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'crates/**'
+      - 'vendor/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.cargo/**'
+      - 'rust-toolchain.toml'
+      - 'clippy.toml'
+      - '.github/workflows/coverage.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'crates/**'
+      - 'vendor/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.cargo/**'
+      - 'rust-toolchain.toml'
+      - 'clippy.toml'
+      - '.github/workflows/coverage.yml'
   schedule:
     - cron: '0 3 * * MON'
   workflow_dispatch:

--- a/.github/workflows/format-lint.yml
+++ b/.github/workflows/format-lint.yml
@@ -2,9 +2,34 @@ name: Format & Lint
 
 on:
   pull_request:
+    paths:
+      - 'crates/**'
+      - 'vendor/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.cargo/**'
+      - 'rust-toolchain.toml'
+      - 'rustfmt.toml'
+      - 'clippy.toml'
+      - '.github/workflows/format-lint.yml'
   push:
     branches:
       - main
+    paths:
+      - 'crates/**'
+      - 'vendor/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.cargo/**'
+      - 'rust-toolchain.toml'
+      - 'rustfmt.toml'
+      - 'clippy.toml'
+      - '.github/workflows/format-lint.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,32 @@ name: Rust CI (tests + clippy)
 
 on:
   pull_request:
+    paths:
+      - 'crates/**'
+      - 'vendor/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.cargo/**'
+      - 'rust-toolchain.toml'
+      - 'clippy.toml'
+      - '.github/workflows/tests.yml'
   push:
     branches:
       - main
+    paths:
+      - 'crates/**'
+      - 'vendor/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.cargo/**'
+      - 'rust-toolchain.toml'
+      - 'clippy.toml'
+      - '.github/workflows/tests.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   tests:


### PR DESCRIPTION
Skip Rust CI (tests, clippy, coverage) when no Rust code changes.
This reduces CI time for docs-only, YAML-only, or script-only PRs
by 5-15 minutes.

Changes:
- Add path filters to tests.yml, format-lint.yml, coverage.yml
  - Triggers on: crates/**, Cargo.toml, Cargo.lock, .cargo/**,
    rust-toolchain.toml, clippy.toml, rustfmt.toml
  - Each workflow self-triggers on its own file changes
- Add concurrency controls to tests.yml and format-lint.yml
  - Cancels in-progress runs when new commits push to same ref
- Add workflow_dispatch to tests.yml and format-lint.yml
  - Enables manual re-runs without code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded CI path-based triggers to watch Rust source, vendored code, Cargo/toolchain/format/lint configs, and workflow files so workflows run only on relevant changes.
  * Added manual run (workflow_dispatch) options for lint and tests workflows.
  * Enabled concurrency controls to group and cancel in-progress workflow runs for lint and tests, avoiding overlapping executions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->