### PR TITLE
refactor(core): extract refresh helpers for MCP reuse

### DIFF
--- a/.agents/rules/LINEAR.md
+++ b/.agents/rules/LINEAR.md
@@ -2,49 +2,79 @@
 
 # LINEAR.md
 
+## Project
+
+- Team: BLZ
+- Key: `BLZ`
+- Workspace: Outfitter
+
+## Streamlinear MCP
+
+This project uses the `streamlinear` MCP server for Linear integration. All actions use a single tool: `mcp__linear__linear`.
+
+### Default Team Filter
+
+Always filter by team `BLZ` when searching:
+
+```json
+{ "action": "search", "query": { "team": "BLZ" } }
+```
+
+### Common Actions
+
+| Action | Example |
+|--------|---------|
+| Search team issues | `{ "action": "search", "query": { "team": "BLZ" } }` |
+| Search in progress | `{ "action": "search", "query": { "team": "BLZ", "state": "In Progress" } }` |
+| Get issue | `{ "action": "get", "id": "BLZ-123" }` |
+| Update status | `{ "action": "update", "id": "BLZ-123", "state": "Done" }` |
+| Add comment | `{ "action": "comment", "id": "BLZ-123", "body": "Comment text" }` |
+| Create issue | `{ "action": "create", "title": "Issue title", "team": "BLZ" }` |
+| GraphQL query | `{ "action": "graphql", "graphql": "query { ... }" }` |
+
 ## Critical Rules
 
 - Linear is the authoritative tracker. Log or locate an issue before meaningful work.
+- Always use team filter `BLZ` when searching to scope results to this project.
 - Keep issues current: status, description, and comments should reflect reality.
 - Use Linear IDs consistently across branches, commits, and pull requests.
 
 ## Workspace Defaults
 
-- When this doc refers to `ID-###`, substitute your team’s prefix (e.g., `BLZ-123`).
 - GitHub issues may sync to different numbers; the Linear ID remains canonical.
 - Issues should enter `Backlog` or `Todo` (not `Triage`) unless triaging is the task.
 - Assign a priority when possible. `Critical` is P0 and should be rare.
 
 ## Workflow Notes
 
-- Status flow: `Backlog` → `Todo` → `In Progress` → `In Review` → `Ready to Merge` → `Done` (adjust per team norms).
+- Status flow: `Backlog` -> `Todo` -> `In Progress` -> `In Review` -> `Ready to Merge` -> `Done`.
 - Attach artifacts (design docs, screenshots) directly to the Linear issue and reference them in commits/PRs when necessary.
-- Keep relationships clear: add dependent/related issues in the body and via Linear’s relationship controls.
+- Keep relationships clear: add dependent/related issues in the body and via Linear's relationship controls.
 
 ## Formatting Issues in Linear
 
-- Link the first reference to another issue inline: `[ID-123](https://linear.app/<workspace>/issue/ID-<num>)`.
-- Subsequent mentions can use `ID-123` with no link.
+- Link the first reference to another issue inline: `[BLZ-123](https://linear.app/outfitter/issue/BLZ-123)`.
+- Subsequent mentions can use `BLZ-123` with no link.
 - Capture definition of done / acceptance criteria directly in the issue.
-- Record dependencies by mentioning related IDs or using Linear’s relationship UI.
+- Record dependencies by mentioning related IDs or using Linear's relationship UI.
 
 ## Referencing Issues in GitHub
 
 ### Branches
 
-- Include the issue ID and slug in the branch name: `id-123-issue-slug`.
-- When possible, use Linear’s **Copy git branch name** helper (Cmd/Ctrl + Shift + .) to pull the canonical slug directly.
+- Include the issue ID and slug in the branch name: `blz-123-issue-slug`.
+- When possible, use Linear's **Copy git branch name** helper (Cmd/Ctrl + Shift + .) to pull the canonical slug directly.
 
 ### Pull Requests
 
-- PR titles follow the conventional-commit style with the ID suffix: `feat: improve pagination [ID-129]`.
-- In PR descriptions, always include a magic word plus ID (`Fixes: ID-129`) if applicable.
+- PR titles follow the conventional-commit style with the ID suffix: `feat: improve pagination [BLZ-129]`.
+- In PR descriptions, always include a magic word plus ID (`Fixes: BLZ-129`) if applicable.
 
 ### Commits
 
 - Conventional commit summary, followed by a footer with Linear magic words:
-  - `Fixes: ID-123` (closing magic word: moves issue to In Progress/Done when merged).
-  - `Refs: ID-123`, `Related: ID-123`, `Part of: ID-123` (non-closing; keeps issue open).
+  - `Fixes: BLZ-123` (closing magic word: moves issue to In Progress/Done when merged).
+  - `Refs: BLZ-123`, `Related: BLZ-123`, `Part of: BLZ-123` (non-closing; keeps issue open).
 - Closing magic words: `close`, `closes`, `closed`, `closing`, `fix`, `fixes`, `fixed`, `fixing`, `resolve`, `resolves`, `resolved`, `resolving`, `complete`, `completes`, `completed`, `completing`.
 - Non-closing magic words: `ref`, `refs`, `references`, `part of`, `related to`, `contributes to`, `toward`, `towards`.
 - Syntax example:
@@ -54,11 +84,11 @@ feat: add context auto expansion
 
 Implements section-aware context expansion with depth limits.
 
-Fixes: ID-135
-Refs: ID-131
+Fixes: BLZ-135
+Refs: BLZ-131
 ```
 
-## Pull Request & Issue comments
+## Pull Request & Issue Comments
 
 - Linear recognizes closing/non-closing magic words in PR descriptions, commits, and comments just like it does in commit footers.
-- Prefer one issue per PR; if a PR spans multiple issues, list each ID explicitly (e.g., `Fixes: ID-101, ID-202`).
+- Prefer one issue per PR; if a PR spans multiple issues, list each ID explicitly (e.g., `Fixes: BLZ-101, BLZ-202`).

--- a/crates/blz-cli/src/commands/add.rs
+++ b/crates/blz-cli/src/commands/add.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use blz_core::{
     Fetcher, LanguageFilter, MarkdownParser, ParseResult, PerformanceMetrics, SearchIndex, Source,
-    SourceDescriptor, SourceOrigin, SourceType, SourceVariant, Storage,
+    SourceDescriptor, SourceOrigin, SourceType, SourceVariant, Storage, build_llms_json,
 };
 use chrono::Utc;
 use colored::Colorize;
@@ -18,9 +18,8 @@ use tokio::fs as async_fs;
 use url::Url;
 
 use crate::utils::count_headings;
-use crate::utils::json_builder::build_llms_json;
-use crate::utils::url_resolver;
 use crate::utils::validation::{normalize_alias, validate_alias};
+use blz_core::url_resolver;
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/blz-cli/src/commands/docs_bundle.rs
+++ b/crates/blz-cli/src/commands/docs_bundle.rs
@@ -8,13 +8,11 @@ use anyhow::{Context, Result};
 use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
 use blz_core::{
     MarkdownParser, PerformanceMetrics, SearchIndex, Source, SourceDescriptor, SourceOrigin,
-    SourceType, SourceVariant, Storage,
+    SourceType, SourceVariant, Storage, build_llms_json,
 };
 use chrono::Utc;
 use sha2::{Digest, Sha256};
 use std::sync::LazyLock;
-
-use crate::utils::json_builder::build_llms_json;
 
 /// Canonical alias for the embedded documentation source.
 pub const BUNDLED_ALIAS: &str = "blz-docs";

--- a/crates/blz-cli/src/commands/refresh.rs
+++ b/crates/blz-cli/src/commands/refresh.rs
@@ -1,243 +1,18 @@
 //! Refresh command implementation
 
-use std::path::PathBuf;
 use std::time::Instant;
 
 use anyhow::{Result, anyhow};
-use blz_core::{
-    FetchResult, Fetcher, HeadingFilterStats, LanguageFilter, MarkdownParser, ParseResult,
-    PerformanceMetrics, SearchIndex, Source, Storage,
+use blz_core::refresh::{
+    DefaultRefreshIndexer, RefreshOutcome, RefreshStorage, RefreshUrlResolution,
+    refresh_source_with_metadata, reindex_source, resolve_refresh_url,
 };
-use chrono::Utc;
+use blz_core::{Fetcher, PerformanceMetrics, Storage};
 use colored::Colorize;
 use indicatif::{ProgressBar, ProgressStyle};
 
-use crate::utils::count_headings;
-use crate::utils::json_builder::build_llms_json;
+use crate::utils::filter_flags;
 use crate::utils::resolver;
-use crate::utils::url_resolver;
-
-/// Abstraction over storage interactions used by the refresh command.
-pub trait RefreshStorage {
-    fn load_metadata(&self, alias: &str) -> Result<Source>;
-    fn load_llms_aliases(&self, alias: &str) -> Result<Vec<String>>;
-    fn save_llms_txt(&self, alias: &str, content: &str) -> Result<()>;
-    fn save_llms_json(&self, alias: &str, data: &blz_core::LlmsJson) -> Result<()>;
-    fn save_metadata(&self, alias: &str, metadata: &Source) -> Result<()>;
-    fn index_path(&self, alias: &str) -> Result<PathBuf>;
-}
-
-#[allow(clippy::use_self)]
-impl RefreshStorage for Storage {
-    fn load_metadata(&self, alias: &str) -> Result<Source> {
-        Storage::load_source_metadata(self, alias)
-            .map_err(anyhow::Error::from)?
-            .ok_or_else(|| anyhow!("Missing metadata for {alias}"))
-    }
-
-    fn load_llms_aliases(&self, alias: &str) -> Result<Vec<String>> {
-        match Storage::load_llms_json(self, alias) {
-            Ok(llms) => Ok(llms.metadata.aliases),
-            Err(_) => Ok(Vec::new()),
-        }
-    }
-
-    fn save_llms_txt(&self, alias: &str, content: &str) -> Result<()> {
-        Storage::save_llms_txt(self, alias, content).map_err(anyhow::Error::from)
-    }
-
-    fn save_llms_json(&self, alias: &str, data: &blz_core::LlmsJson) -> Result<()> {
-        Storage::save_llms_json(self, alias, data).map_err(anyhow::Error::from)
-    }
-
-    fn save_metadata(&self, alias: &str, metadata: &Source) -> Result<()> {
-        Storage::save_source_metadata(self, alias, metadata).map_err(anyhow::Error::from)
-    }
-
-    fn index_path(&self, alias: &str) -> Result<PathBuf> {
-        Storage::index_dir(self, alias).map_err(anyhow::Error::from)
-    }
-}
-
-/// Interface for indexing refreshed content.
-pub trait RefreshIndexer {
-    fn index(
-        &self,
-        alias: &str,
-        index_path: &std::path::Path,
-        metrics: PerformanceMetrics,
-        blocks: &[blz_core::HeadingBlock],
-    ) -> Result<()>;
-}
-
-#[derive(Default)]
-struct DefaultIndexer;
-
-impl RefreshIndexer for DefaultIndexer {
-    fn index(
-        &self,
-        alias: &str,
-        index_path: &std::path::Path,
-        metrics: PerformanceMetrics,
-        blocks: &[blz_core::HeadingBlock],
-    ) -> Result<()> {
-        let index = SearchIndex::create_or_open(index_path)?.with_metrics(metrics);
-        index
-            .index_blocks(alias, blocks)
-            .map_err(anyhow::Error::from)
-    }
-}
-
-/// Result summary for a refresh operation.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum RefreshOutcome {
-    Refreshed {
-        alias: String,
-        headings: usize,
-        lines: usize,
-    },
-    Unchanged {
-        alias: String,
-    },
-}
-
-/// Data describing remote changes.
-#[derive(Debug, Clone)]
-pub struct RefreshPayload {
-    pub content: String,
-    pub sha256: String,
-    pub etag: Option<String>,
-    pub last_modified: Option<String>,
-}
-
-/// Apply a refresh: persist content and re-index the source.
-#[allow(clippy::too_many_arguments)]
-#[allow(clippy::too_many_lines)]
-pub fn apply_refresh<S, I>(
-    storage: &S,
-    alias: &str,
-    existing_metadata: Source,
-    existing_aliases: Vec<String>,
-    payload: RefreshPayload,
-    metrics: PerformanceMetrics,
-    indexer: &I,
-    quiet: bool,
-) -> Result<RefreshOutcome>
-where
-    S: RefreshStorage,
-    I: RefreshIndexer,
-{
-    let mut parser = MarkdownParser::new()?;
-    let mut parse_result = parser.parse(&payload.content)?;
-
-    // Apply language filtering based on stored preference
-    let original_heading_count = parse_result.heading_blocks.len();
-    let filter_enabled = existing_metadata.filter_non_english.unwrap_or(true);
-    apply_language_filter(&mut parse_result, !filter_enabled, quiet);
-
-    // Calculate and store filter stats
-    let filtered_count = original_heading_count.saturating_sub(parse_result.heading_blocks.len());
-    let filter_stats = Some(HeadingFilterStats {
-        enabled: filter_enabled,
-        headings_total: original_heading_count,
-        headings_accepted: parse_result.heading_blocks.len(),
-        headings_rejected: filtered_count,
-        reason: if filter_enabled {
-            "non-English content removed".to_string()
-        } else {
-            "filtering disabled".to_string()
-        },
-    });
-
-    storage.save_llms_txt(alias, &payload.content)?;
-
-    let mut llms_json = build_llms_json(
-        alias,
-        &existing_metadata.url,
-        "llms.txt",
-        payload.sha256.clone(),
-        payload.etag.clone(),
-        payload.last_modified.clone(),
-        &parse_result,
-    );
-
-    let mut metadata_aliases = existing_aliases;
-    for alias_value in &existing_metadata.aliases {
-        if !metadata_aliases.contains(alias_value) {
-            metadata_aliases.push(alias_value.clone());
-        }
-    }
-    metadata_aliases.sort();
-    metadata_aliases.dedup();
-    llms_json.metadata.aliases = metadata_aliases;
-    llms_json.metadata.tags.clone_from(&existing_metadata.tags);
-    llms_json
-        .metadata
-        .description
-        .clone_from(&existing_metadata.description);
-    llms_json
-        .metadata
-        .category
-        .clone_from(&existing_metadata.category);
-    llms_json
-        .metadata
-        .npm_aliases
-        .clone_from(&existing_metadata.npm_aliases);
-    llms_json
-        .metadata
-        .github_aliases
-        .clone_from(&existing_metadata.github_aliases);
-    llms_json.metadata.variant = existing_metadata.variant.clone();
-    llms_json.filter_stats = filter_stats;
-    storage.save_llms_json(alias, &llms_json)?;
-
-    let mut origin = existing_metadata.origin.clone();
-    origin.source_type = match (&origin.source_type, &existing_metadata.origin.source_type) {
-        (Some(blz_core::SourceType::Remote { .. }), _) | (None, None) => {
-            Some(blz_core::SourceType::Remote {
-                url: existing_metadata.url.clone(),
-            })
-        },
-        (Some(blz_core::SourceType::LocalFile { path }), _) => {
-            Some(blz_core::SourceType::LocalFile { path: path.clone() })
-        },
-        (None, Some(existing)) => Some(existing.clone()),
-    };
-
-    llms_json.metadata.origin = origin.clone();
-
-    let metadata = Source {
-        url: existing_metadata.url,
-        etag: payload.etag,
-        last_modified: payload.last_modified,
-        fetched_at: Utc::now(),
-        sha256: payload.sha256,
-        variant: existing_metadata.variant,
-        aliases: existing_metadata.aliases,
-        tags: existing_metadata.tags,
-        description: existing_metadata.description,
-        category: existing_metadata.category,
-        npm_aliases: existing_metadata.npm_aliases,
-        github_aliases: existing_metadata.github_aliases,
-        origin,
-        filter_non_english: existing_metadata.filter_non_english,
-    };
-    storage.save_metadata(alias, &metadata)?;
-
-    let index_path = storage.index_path(alias)?;
-    indexer.index(
-        alias,
-        index_path.as_path(),
-        metrics,
-        &parse_result.heading_blocks,
-    )?;
-
-    Ok(RefreshOutcome::Refreshed {
-        alias: alias.to_string(),
-        headings: count_headings(&llms_json.toc),
-        lines: llms_json.line_index.total_lines,
-    })
-}
 
 fn create_spinner(message: &str) -> ProgressBar {
     let pb = ProgressBar::new_spinner();
@@ -250,7 +25,7 @@ fn create_spinner(message: &str) -> ProgressBar {
     pb
 }
 
-/// Execute reindex: re-parse and re-index from cached content
+/// Execute reindex: re-parse and re-index from cached content.
 fn execute_reindex(
     storage: &Storage,
     alias: &str,
@@ -267,56 +42,33 @@ fn execute_reindex(
 
     let start = Instant::now();
 
-    // Load existing metadata to determine filter preference
-    let existing_metadata = storage.load_metadata(alias)?;
+    let existing_metadata = storage.load_metadata(alias).map_err(anyhow::Error::from)?;
 
-    // Parse filter flags and determine filter preference
-    let filter_flags = crate::utils::filter_flags::parse_filter_flags(filter);
+    let filter_flags = filter_flags::parse_filter_flags(filter);
     let filter_preference = if no_filter {
         false
     } else if filter_flags.any_enabled() {
         filter_flags.language
     } else {
-        // Use stored preference or default
         existing_metadata.filter_non_english.unwrap_or(true)
     };
 
-    // Load cached llms.txt content
-    let content = storage.load_llms_txt(alias)?;
-
-    // Parse the content
-    let mut parser = MarkdownParser::new()?;
-    let mut parse_result = parser.parse(&content)?;
-
-    // Show before stats
-    let before_count = parse_result.heading_blocks.len();
-
-    // Apply filtering
-    apply_language_filter(&mut parse_result, !filter_preference, quiet);
-
-    // Show after stats
-    let after_count = parse_result.heading_blocks.len();
-    let filtered_count = before_count.saturating_sub(after_count);
-
-    spinner.set_message(format!("Indexing {alias}..."));
-
-    // Re-index
-    let index_path = storage.index_dir(alias)?;
-    let index = SearchIndex::create_or_open(&index_path)?.with_metrics(metrics);
-    index.index_blocks(alias, &parse_result.heading_blocks)?;
+    let indexer = DefaultRefreshIndexer;
+    let outcome = reindex_source(storage, alias, metrics, &indexer, filter_preference)?;
 
     spinner.finish_and_clear();
 
     if !quiet {
         let elapsed = start.elapsed();
+        let filtered_count = outcome.filtered;
         if filtered_count > 0 {
             println!(
                 "{} {}: {} → {} headings ({:.1}% {}) in {:?}",
                 "✓ Re-indexed".green(),
                 alias.green(),
-                before_count,
-                after_count,
-                percentage(filtered_count, before_count),
+                outcome.headings_before,
+                outcome.headings_after,
+                percentage(filtered_count, outcome.headings_before),
                 if filter_preference {
                     "filtered"
                 } else {
@@ -329,13 +81,30 @@ fn execute_reindex(
                 "{} {}: {} headings in {:?}",
                 "✓ Re-indexed".green(),
                 alias.green(),
-                after_count,
+                outcome.headings_after,
                 elapsed
             );
         }
     }
 
     Ok(())
+}
+
+fn announce_upgrade(resolution: &RefreshUrlResolution, alias: &str, quiet: bool) {
+    if !resolution.upgraded || quiet {
+        return;
+    }
+
+    println!(
+        "{} llms-full.txt is now available for {}",
+        "✨".green(),
+        alias.green()
+    );
+    println!(
+        "  Upgrading from {} to {}",
+        "llms.txt".yellow(),
+        "llms-full.txt".green()
+    );
 }
 
 /// Execute refresh for a specific source.
@@ -356,7 +125,6 @@ pub async fn execute(
         return Err(anyhow!("Source '{alias}' not found"));
     }
 
-    // Handle reindex flag: re-parse and re-index from cached content
     if reindex {
         return execute_reindex(
             &storage,
@@ -379,7 +147,7 @@ pub async fn execute(
     let existing_aliases = storage.load_llms_aliases(&canonical_alias)?;
     let fetcher = Fetcher::new()?;
 
-    let filter_flags = crate::utils::filter_flags::parse_filter_flags(filter);
+    let filter_flags = filter_flags::parse_filter_flags(filter);
     let filter_preference = if no_filter {
         false
     } else if filter_flags.any_enabled() {
@@ -388,108 +156,23 @@ pub async fn execute(
         existing_metadata.filter_non_english.unwrap_or(true)
     };
 
-    // Check for URL upgrades (llms.txt -> llms-full.txt)
-    let (final_url, updated_variant) = if existing_metadata.variant == blz_core::SourceVariant::Llms
-    {
-        // Try to resolve a better variant
-        match url_resolver::resolve_best_url(&fetcher, &existing_metadata.url).await {
-            Ok(resolved) if resolved.variant == blz_core::SourceVariant::LlmsFull => {
-                if !quiet {
-                    spinner.finish_and_clear();
-                    println!(
-                        "{} llms-full.txt is now available for {}",
-                        "✨".green(),
-                        canonical_alias.green()
-                    );
-                    println!(
-                        "  Upgrading from {} to {}",
-                        "llms.txt".yellow(),
-                        "llms-full.txt".green()
-                    );
-                }
-                (resolved.final_url, resolved.variant)
-            },
-            Ok(_resolved) => {
-                // No upgrade available, use existing URL
-                (
-                    existing_metadata.url.clone(),
-                    existing_metadata.variant.clone(),
-                )
-            },
-            Err(_) => {
-                // Resolution failed, use existing URL
-                (
-                    existing_metadata.url.clone(),
-                    existing_metadata.variant.clone(),
-                )
-            },
-        }
-    } else {
-        // Already using llms-full or custom URL, no upgrade needed
-        (
-            existing_metadata.url.clone(),
-            existing_metadata.variant.clone(),
-        )
-    };
+    let resolution = resolve_refresh_url(&fetcher, &existing_metadata).await?;
+    spinner.finish_and_clear();
+    announce_upgrade(&resolution, &canonical_alias, quiet);
 
-    let fetch_result = fetcher
-        .fetch_with_cache(
-            &final_url,
-            existing_metadata.etag.as_deref(),
-            existing_metadata.last_modified.as_deref(),
-        )
-        .await?;
-
-    let outcome = match fetch_result {
-        FetchResult::NotModified { .. } => {
-            spinner.finish_and_clear();
-            if existing_metadata.filter_non_english.unwrap_or(true) != filter_preference {
-                let mut updated_metadata = existing_metadata.clone();
-                updated_metadata.filter_non_english = Some(filter_preference);
-                storage.save_metadata(&canonical_alias, &updated_metadata)?;
-            }
-            if !quiet {
-                println!("{} {} (unchanged)", "✓".green(), canonical_alias.green());
-            }
-            RefreshOutcome::Unchanged {
-                alias: canonical_alias.clone(),
-            }
-        },
-        FetchResult::Modified {
-            content,
-            sha256,
-            etag,
-            last_modified,
-        } => {
-            spinner.set_message(format!("Parsing {canonical_alias}..."));
-            let payload = RefreshPayload {
-                content,
-                sha256,
-                etag,
-                last_modified,
-            };
-            let indexer = DefaultIndexer;
-
-            // Refresh metadata with new URL and variant if upgraded
-            let mut updated_metadata = existing_metadata.clone();
-            updated_metadata.url = final_url;
-            updated_metadata.variant = updated_variant;
-            updated_metadata.filter_non_english = Some(filter_preference);
-
-            let outcome = apply_refresh(
-                &storage,
-                &canonical_alias,
-                updated_metadata,
-                existing_aliases,
-                payload,
-                metrics,
-                &indexer,
-                quiet,
-            )?;
-            spinner.finish_and_clear();
-            outcome
-        },
-    };
+    let indexer = DefaultRefreshIndexer;
+    let outcome = refresh_source_with_metadata(
+        &storage,
+        &fetcher,
+        &canonical_alias,
+        existing_metadata,
+        existing_aliases,
+        &resolution,
+        metrics,
+        &indexer,
+        filter_preference,
+    )
+    .await?;
 
     if !quiet {
         let elapsed = start.elapsed();
@@ -534,7 +217,6 @@ pub async fn execute_all(
         anyhow::bail!("No sources configured. Use 'blz add' to add sources.");
     }
 
-    // If reindexing, handle each source synchronously with reindex logic
     if reindex {
         let mut updated_count = 0;
         let mut error_count = 0;
@@ -573,8 +255,8 @@ pub async fn execute_all(
     let mut refreshed_count = 0;
     let mut skipped_count = 0;
     let mut error_count = 0;
-    let indexer = DefaultIndexer;
-    let filter_flags = crate::utils::filter_flags::parse_filter_flags(filter);
+    let indexer = DefaultRefreshIndexer;
+    let filter_flags = filter_flags::parse_filter_flags(filter);
 
     for alias in sources {
         let spinner = if quiet {
@@ -583,15 +265,8 @@ pub async fn execute_all(
             create_spinner(format!("Checking {alias}...").as_str())
         };
 
-        let mut metadata = storage.load_metadata(&alias)?;
+        let metadata = storage.load_metadata(&alias)?;
         let aliases = storage.load_llms_aliases(&alias)?;
-        let fetch_result = fetcher
-            .fetch_with_cache(
-                &metadata.url,
-                metadata.etag.as_deref(),
-                metadata.last_modified.as_deref(),
-            )
-            .await?;
 
         let filter_preference = if no_filter {
             false
@@ -601,61 +276,40 @@ pub async fn execute_all(
             metadata.filter_non_english.unwrap_or(true)
         };
 
-        match fetch_result {
-            FetchResult::NotModified { .. } => {
-                spinner.finish_and_clear();
-                if metadata.filter_non_english.unwrap_or(true) != filter_preference {
-                    metadata.filter_non_english = Some(filter_preference);
-                    storage.save_metadata(&alias, &metadata)?;
+        let resolution = resolve_refresh_url(&fetcher, &metadata).await?;
+        spinner.finish_and_clear();
+        announce_upgrade(&resolution, &alias, quiet);
+
+        match refresh_source_with_metadata(
+            &storage,
+            &fetcher,
+            &alias,
+            metadata,
+            aliases,
+            &resolution,
+            metrics.clone(),
+            &indexer,
+            filter_preference,
+        )
+        .await
+        {
+            Ok(RefreshOutcome::Refreshed { .. }) => {
+                refreshed_count += 1;
+                if !quiet {
+                    println!("{} {}", "✓ Refreshed".green(), alias.green());
                 }
+            },
+            Ok(RefreshOutcome::Unchanged { .. }) => {
                 skipped_count += 1;
                 if !quiet {
                     println!("{} {} (unchanged)", "✓".green(), alias.green());
                 }
             },
-            FetchResult::Modified {
-                content,
-                sha256,
-                etag,
-                last_modified,
-            } => {
-                spinner.set_message(format!("Parsing {alias}..."));
-                metadata.filter_non_english = Some(filter_preference);
-
-                match apply_refresh(
-                    &storage,
-                    &alias,
-                    metadata,
-                    aliases,
-                    RefreshPayload {
-                        content,
-                        sha256,
-                        etag,
-                        last_modified,
-                    },
-                    metrics.clone(),
-                    &indexer,
-                    quiet,
-                ) {
-                    Ok(RefreshOutcome::Refreshed { .. }) => {
-                        refreshed_count += 1;
-                        spinner.finish_and_clear();
-                        if !quiet {
-                            println!("{} {}", "✓ Refreshed".green(), alias.green());
-                        }
-                    },
-                    Ok(RefreshOutcome::Unchanged { .. }) => {
-                        skipped_count += 1;
-                        spinner.finish_and_clear();
-                    },
-                    Err(e) => {
-                        spinner.finish_and_clear();
-                        if !quiet {
-                            eprintln!("{}: {}", alias.red(), e);
-                        }
-                        error_count += 1;
-                    },
+            Err(e) => {
+                if !quiet {
+                    eprintln!("{}: {}", alias.red(), e);
                 }
+                error_count += 1;
             },
         }
     }
@@ -677,243 +331,11 @@ pub async fn execute_all(
     Ok(())
 }
 
-/// Apply language filtering to parse results
-///
-/// Filters out non-English heading blocks using hybrid URL-based and text-based detection.
-/// Prints filtering statistics if blocks were filtered and not in quiet mode.
-fn apply_language_filter(parse_result: &mut ParseResult, no_language_filter: bool, quiet: bool) {
-    if no_language_filter {
-        return;
-    }
-
-    let mut language_filter = LanguageFilter::new(true);
-
-    // Filter heading blocks using both URL-based and text-based methods
-    let original_count = parse_result.heading_blocks.len();
-    parse_result.heading_blocks.retain(|block| {
-        // First check URLs in content (fast, catches locale-based URLs)
-        let urls_in_content = extract_urls_from_content(&block.content);
-        let url_check = urls_in_content.is_empty()
-            || urls_in_content
-                .iter()
-                .all(|url| language_filter.is_english_url(url));
-
-        // Then check heading text (catches non-URL-based translations)
-        let heading_check = language_filter.is_english_heading_path(&block.path);
-
-        // Block must pass both checks to be kept
-        url_check && heading_check
-    });
-
-    let filtered_count = original_count - parse_result.heading_blocks.len();
-    if filtered_count > 0 && !quiet {
-        println!(
-            "Filtered {} non-English content blocks ({:.1}% reduction)",
-            filtered_count,
-            percentage(filtered_count, original_count)
-        );
-    }
-}
-
 #[allow(clippy::cast_precision_loss)]
 fn percentage(part: usize, total: usize) -> f64 {
     if total == 0 {
         0.0
     } else {
         (part as f64 / total as f64) * 100.0
-    }
-}
-
-/// Extract URLs from markdown content using simple string parsing
-fn extract_urls_from_content(content: &str) -> Vec<String> {
-    let mut urls = Vec::new();
-
-    let mut search_start = 0;
-    while let Some(rel) = content[search_start..].find('[') {
-        let open_idx = search_start + rel;
-        if let Some(close_rel) = content[open_idx + 1..].find(']') {
-            let close_idx = open_idx + 1 + close_rel;
-            let after_bracket = content.get(close_idx + 1..).unwrap_or("");
-            if let Some(rest) = after_bracket.strip_prefix('(') {
-                if let Some(paren_rel) = rest.find(')') {
-                    if let Some(cleaned) = clean_url_slice(&rest[..paren_rel]) {
-                        urls.push(cleaned.to_string());
-                    }
-                }
-            }
-        }
-        search_start = open_idx + 1;
-    }
-
-    urls
-}
-
-/// Helper to clean a URL slice by trimming whitespace and quotes
-fn clean_url_slice(s: &str) -> Option<&str> {
-    let trimmed = s.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-
-    let trimmed = trimmed
-        .strip_prefix('"')
-        .or_else(|| trimmed.strip_prefix('\''))
-        .unwrap_or(trimmed);
-
-    let trimmed = trimmed
-        .strip_suffix('"')
-        .or_else(|| trimmed.strip_suffix('\''))
-        .unwrap_or(trimmed);
-
-    // Trim trailing punctuation
-    let mut end = trimmed.len();
-    for (idx, ch) in trimmed.char_indices().rev() {
-        if trailing_punctuation(ch) {
-            end = idx;
-        } else {
-            break;
-        }
-    }
-
-    if end == 0 {
-        None
-    } else {
-        Some(&trimmed[..end])
-    }
-}
-
-const fn trailing_punctuation(c: char) -> bool {
-    matches!(c, ',' | '.' | ';' | ':' | '!' | '?')
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::cell::RefCell;
-    use std::collections::HashMap;
-
-    use anyhow::Result;
-
-    #[derive(Default)]
-    struct MockStorage {
-        metadata: HashMap<String, Source>,
-        saved_txt: RefCell<Vec<String>>, // aliases that called save_llms_txt
-        saved_json: RefCell<Vec<String>>, // aliases that called save_llms_json
-        saved_metadata: RefCell<Vec<Source>>,
-        index_paths: HashMap<String, PathBuf>,
-    }
-
-    impl RefreshStorage for MockStorage {
-        fn load_metadata(&self, alias: &str) -> Result<Source> {
-            self.metadata
-                .get(alias)
-                .cloned()
-                .ok_or_else(|| anyhow!("missing metadata"))
-        }
-
-        fn load_llms_aliases(&self, _alias: &str) -> Result<Vec<String>> {
-            Ok(Vec::new())
-        }
-
-        fn save_llms_txt(&self, alias: &str, _content: &str) -> Result<()> {
-            self.saved_txt.borrow_mut().push(alias.to_string());
-            Ok(())
-        }
-
-        fn save_llms_json(&self, alias: &str, _data: &blz_core::LlmsJson) -> Result<()> {
-            self.saved_json.borrow_mut().push(alias.to_string());
-            Ok(())
-        }
-
-        fn save_metadata(&self, _alias: &str, metadata: &Source) -> Result<()> {
-            self.saved_metadata.borrow_mut().push(metadata.clone());
-            Ok(())
-        }
-
-        fn index_path(&self, alias: &str) -> Result<PathBuf> {
-            self.index_paths
-                .get(alias)
-                .cloned()
-                .ok_or_else(|| anyhow!("missing index path"))
-        }
-    }
-
-    #[derive(Default)]
-    struct MockIndexer {
-        indexed: RefCell<Vec<String>>,
-    }
-
-    impl RefreshIndexer for MockIndexer {
-        fn index(
-            &self,
-            alias: &str,
-            _index_path: &std::path::Path,
-            _metrics: PerformanceMetrics,
-            _blocks: &[blz_core::HeadingBlock],
-        ) -> Result<()> {
-            self.indexed.borrow_mut().push(alias.to_string());
-            Ok(())
-        }
-    }
-
-    fn sample_source() -> Source {
-        Source {
-            url: "https://example.com".into(),
-            etag: Some("etag".into()),
-            last_modified: Some("Wed, 01 Oct 2025 12:00:00 GMT".into()),
-            fetched_at: Utc::now(),
-            sha256: "sha".into(),
-            variant: blz_core::SourceVariant::Llms,
-            aliases: vec!["alpha".into()],
-            tags: vec!["docs".into()],
-            description: Some("Example source".into()),
-            category: Some("library".into()),
-            npm_aliases: vec!["alpha".into()],
-            github_aliases: vec!["org/alpha".into()],
-            origin: blz_core::SourceOrigin {
-                manifest: None,
-                source_type: Some(blz_core::SourceType::Remote {
-                    url: "https://example.com".into(),
-                }),
-            },
-            filter_non_english: Some(true),
-        }
-    }
-
-    fn sample_payload() -> RefreshPayload {
-        RefreshPayload {
-            content: "# Title\n\nContent".into(),
-            sha256: "new-sha".into(),
-            etag: Some("new-etag".into()),
-            last_modified: Some("Thu, 02 Oct 2025 12:00:00 GMT".into()),
-        }
-    }
-
-    #[test]
-    fn apply_refresh_persists_changes() -> Result<()> {
-        let mut storage = MockStorage::default();
-        storage.metadata.insert("alpha".into(), sample_source());
-        storage
-            .index_paths
-            .insert("alpha".into(), PathBuf::from("index"));
-
-        let indexer = MockIndexer::default();
-        let outcome = apply_refresh(
-            &storage,
-            "alpha",
-            sample_source(),
-            vec!["canonical".into()],
-            sample_payload(),
-            PerformanceMetrics::default(),
-            &indexer,
-            false, // quiet
-        )?;
-
-        assert!(matches!(outcome, RefreshOutcome::Refreshed { .. }));
-        assert_eq!(storage.saved_txt.borrow().as_slice(), ["alpha"]);
-        assert_eq!(storage.saved_json.borrow().as_slice(), ["alpha"]);
-        assert_eq!(indexer.indexed.borrow().as_slice(), ["alpha"]);
-        assert_eq!(storage.saved_metadata.borrow().len(), 1);
-        Ok(())
     }
 }

--- a/crates/blz-cli/src/commands/update.rs
+++ b/crates/blz-cli/src/commands/update.rs
@@ -9,15 +9,15 @@ use std::time::Instant;
 use anyhow::{Result, anyhow};
 use blz_core::{
     FetchResult, Fetcher, MarkdownParser, PerformanceMetrics, SearchIndex, Source, Storage,
+    build_llms_json,
 };
 use chrono::Utc;
 use colored::Colorize;
 use indicatif::{ProgressBar, ProgressStyle};
 
 use crate::utils::count_headings;
-use crate::utils::json_builder::build_llms_json;
 use crate::utils::resolver;
-use crate::utils::url_resolver;
+use blz_core::url_resolver;
 
 /// Abstraction over storage interactions used by the update command.
 pub trait UpdateStorage {

--- a/crates/blz-cli/src/utils/mod.rs
+++ b/crates/blz-cli/src/utils/mod.rs
@@ -58,7 +58,6 @@ pub mod filter_flags;
 pub mod formatting;
 pub mod heading_filter;
 pub mod history_log;
-pub mod json_builder;
 pub mod parsing;
 pub mod preferences;
 pub mod process_guard;
@@ -67,7 +66,6 @@ pub mod settings;
 pub mod staleness;
 pub mod store;
 pub mod toc;
-pub mod url_resolver;
 pub mod validation;
 
 #[cfg(test)]

--- a/crates/blz-core/src/json_builder.rs
+++ b/crates/blz-core/src/json_builder.rs
@@ -1,12 +1,14 @@
-//! Helper utilities for building blz-core JSON structures
+//! Helper utilities for building blz-core JSON structures.
 
-use blz_core::{FileInfo, LineIndex, LlmsJson, ParseMeta, ParseResult, Source};
 use chrono::Utc;
 
-/// Build a `LlmsJson` structure from parse results and metadata
+use crate::{FileInfo, LineIndex, LlmsJson, ParseMeta, ParseResult, Source};
+
+/// Build a `LlmsJson` structure from parse results and metadata.
 ///
 /// This helper constructs the complete JSON structure that gets saved
 /// to disk for each source, containing TOC, line index, and metadata.
+#[must_use]
 pub fn build_llms_json(
     alias: &str,
     url: &str,
@@ -24,16 +26,16 @@ pub fn build_llms_json(
             last_modified,
             fetched_at: Utc::now(),
             sha256: sha256.clone(),
-            variant: blz_core::SourceVariant::Llms, // Default, will be updated by caller
+            variant: crate::SourceVariant::Llms, // Default, caller can override.
             aliases: Vec::new(),
             tags: Vec::new(),
             description: None,
             category: None,
             npm_aliases: Vec::new(),
             github_aliases: Vec::new(),
-            origin: blz_core::SourceOrigin {
+            origin: crate::SourceOrigin {
                 manifest: None,
-                source_type: Some(blz_core::SourceType::Remote {
+                source_type: Some(crate::SourceType::Remote {
                     url: url.to_string(),
                 }),
             },

--- a/crates/blz-core/src/lib.rs
+++ b/crates/blz-core/src/lib.rs
@@ -65,6 +65,8 @@ pub mod fetcher;
 pub mod heading;
 /// Search index implementation using Tantivy
 pub mod index;
+/// JSON builder helpers for llms.json structures
+pub mod json_builder;
 /// Language filtering for multilingual llms.txt files
 pub mod language_filter;
 /// Anchor remapping utilities between versions
@@ -75,12 +77,16 @@ pub mod parser;
 pub mod profile;
 /// Performance profiling utilities
 pub mod profiling;
+/// Refresh helpers shared across CLI and MCP
+pub mod refresh;
 /// Built-in registry of known documentation sources
 pub mod registry;
 /// Local filesystem storage for cached documentation
 pub mod storage;
 /// Core data types and structures
 pub mod types;
+/// URL resolver for llms.txt variants
+pub mod url_resolver;
 
 // Re-export commonly used types
 pub use config::{
@@ -94,6 +100,7 @@ pub use heading::{
     segment_variants,
 };
 pub use index::SearchIndex;
+pub use json_builder::build_llms_json;
 pub use language_filter::{FilterStats, LanguageFilter};
 pub use mapping::{build_anchors_map, compute_anchor_mappings};
 pub use parser::{MarkdownParser, ParseResult};

--- a/crates/blz-core/src/refresh.rs
+++ b/crates/blz-core/src/refresh.rs
@@ -1,0 +1,662 @@
+//! Refresh helpers shared by CLI and MCP consumers.
+
+use std::path::PathBuf;
+
+use crate::{
+    FetchResult, Fetcher, HeadingFilterStats, LanguageFilter, MarkdownParser, ParseResult,
+    PerformanceMetrics, Result, SearchIndex, Source, SourceType, Storage, TocEntry,
+};
+
+use crate::json_builder::build_llms_json;
+use crate::url_resolver::resolve_best_url;
+
+/// Abstraction over storage interactions used by refresh routines.
+pub trait RefreshStorage {
+    /// Load stored metadata for a source alias.
+    fn load_metadata(&self, alias: &str) -> Result<Source>;
+    /// Load alias list from the cached llms.json for a source.
+    fn load_llms_aliases(&self, alias: &str) -> Result<Vec<String>>;
+    /// Persist the latest llms.txt content.
+    fn save_llms_txt(&self, alias: &str, content: &str) -> Result<()>;
+    /// Persist the computed llms.json metadata payload.
+    fn save_llms_json(&self, alias: &str, data: &crate::LlmsJson) -> Result<()>;
+    /// Persist updated source metadata.
+    fn save_metadata(&self, alias: &str, metadata: &Source) -> Result<()>;
+    /// Resolve the on-disk index path for a source.
+    fn index_path(&self, alias: &str) -> Result<PathBuf>;
+    /// Load cached llms.txt content for a source.
+    fn load_llms_txt(&self, alias: &str) -> Result<String>;
+}
+
+impl RefreshStorage for Storage {
+    fn load_metadata(&self, alias: &str) -> Result<Source> {
+        Self::load_source_metadata(self, alias)?
+            .ok_or_else(|| crate::Error::NotFound(format!("Missing metadata for {alias}")))
+    }
+
+    fn load_llms_aliases(&self, alias: &str) -> Result<Vec<String>> {
+        match Self::load_llms_json(self, alias) {
+            Ok(llms) => Ok(llms.metadata.aliases),
+            Err(_) => Ok(Vec::new()),
+        }
+    }
+
+    fn save_llms_txt(&self, alias: &str, content: &str) -> Result<()> {
+        Self::save_llms_txt(self, alias, content)
+    }
+
+    fn save_llms_json(&self, alias: &str, data: &crate::LlmsJson) -> Result<()> {
+        Self::save_llms_json(self, alias, data)
+    }
+
+    fn save_metadata(&self, alias: &str, metadata: &Source) -> Result<()> {
+        Self::save_source_metadata(self, alias, metadata)
+    }
+
+    fn index_path(&self, alias: &str) -> Result<PathBuf> {
+        Self::index_dir(self, alias)
+    }
+
+    fn load_llms_txt(&self, alias: &str) -> Result<String> {
+        Self::load_llms_txt(self, alias)
+    }
+}
+
+/// Interface for indexing refreshed content.
+pub trait RefreshIndexer {
+    /// Index a set of heading blocks for the given alias.
+    fn index(
+        &self,
+        alias: &str,
+        index_path: &std::path::Path,
+        metrics: PerformanceMetrics,
+        blocks: &[crate::HeadingBlock],
+    ) -> Result<()>;
+}
+
+/// Default indexer that writes to the Tantivy search index.
+#[derive(Default)]
+pub struct DefaultRefreshIndexer;
+
+impl RefreshIndexer for DefaultRefreshIndexer {
+    fn index(
+        &self,
+        alias: &str,
+        index_path: &std::path::Path,
+        metrics: PerformanceMetrics,
+        blocks: &[crate::HeadingBlock],
+    ) -> Result<()> {
+        let index = SearchIndex::create_or_open(index_path)?.with_metrics(metrics);
+        index.index_blocks(alias, blocks)
+    }
+}
+
+/// Result summary for a refresh operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RefreshOutcome {
+    /// The source content changed and was re-indexed.
+    Refreshed {
+        /// Canonical alias for the refreshed source.
+        alias: String,
+        /// Number of headings indexed.
+        headings: usize,
+        /// Total line count in the source.
+        lines: usize,
+    },
+    /// The source content was unchanged.
+    Unchanged {
+        /// Canonical alias for the unchanged source.
+        alias: String,
+    },
+}
+
+/// Result summary for a reindex operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReindexOutcome {
+    /// Canonical alias for the reindexed source.
+    pub alias: String,
+    /// Heading count before filtering.
+    pub headings_before: usize,
+    /// Heading count after filtering.
+    pub headings_after: usize,
+    /// Number of headings filtered out.
+    pub filtered: usize,
+}
+
+/// Data describing remote changes.
+#[derive(Debug, Clone)]
+pub struct RefreshPayload {
+    /// Refreshed llms.txt content.
+    pub content: String,
+    /// SHA256 hash of the refreshed content.
+    pub sha256: String,
+    /// `ETag` header value from the response.
+    pub etag: Option<String>,
+    /// Last-Modified header value from the response.
+    pub last_modified: Option<String>,
+}
+
+/// URL resolution details for refresh operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RefreshUrlResolution {
+    /// Final URL used for refresh.
+    pub final_url: String,
+    /// Variant chosen for the URL.
+    pub variant: crate::SourceVariant,
+    /// Whether the source was upgraded to llms-full.txt.
+    pub upgraded: bool,
+}
+
+/// Resolve the best refresh URL (llms.txt → llms-full.txt) when available.
+pub async fn resolve_refresh_url(
+    fetcher: &Fetcher,
+    metadata: &Source,
+) -> Result<RefreshUrlResolution> {
+    if metadata.variant != crate::SourceVariant::Llms {
+        return Ok(RefreshUrlResolution {
+            final_url: metadata.url.clone(),
+            variant: metadata.variant.clone(),
+            upgraded: false,
+        });
+    }
+
+    match resolve_best_url(fetcher, &metadata.url).await {
+        Ok(resolved) if resolved.variant == crate::SourceVariant::LlmsFull => {
+            Ok(RefreshUrlResolution {
+                final_url: resolved.final_url,
+                variant: resolved.variant,
+                upgraded: true,
+            })
+        },
+        Ok(_) | Err(_) => Ok(RefreshUrlResolution {
+            final_url: metadata.url.clone(),
+            variant: metadata.variant.clone(),
+            upgraded: false,
+        }),
+    }
+}
+
+/// Refresh a source using its current metadata.
+pub async fn refresh_source<S, I>(
+    storage: &S,
+    fetcher: &Fetcher,
+    alias: &str,
+    metrics: PerformanceMetrics,
+    indexer: &I,
+    filter_preference: bool,
+) -> Result<RefreshOutcome>
+where
+    S: RefreshStorage + Sync,
+    I: RefreshIndexer + Sync,
+{
+    let existing_metadata = storage.load_metadata(alias)?;
+    let existing_aliases = storage.load_llms_aliases(alias)?;
+    let resolution = resolve_refresh_url(fetcher, &existing_metadata).await?;
+
+    refresh_source_with_metadata(
+        storage,
+        fetcher,
+        alias,
+        existing_metadata,
+        existing_aliases,
+        &resolution,
+        metrics,
+        indexer,
+        filter_preference,
+    )
+    .await
+}
+
+/// Refresh a source using preloaded metadata and URL resolution.
+#[allow(clippy::too_many_arguments)]
+pub async fn refresh_source_with_metadata<S, I>(
+    storage: &S,
+    fetcher: &Fetcher,
+    alias: &str,
+    existing_metadata: Source,
+    existing_aliases: Vec<String>,
+    resolution: &RefreshUrlResolution,
+    metrics: PerformanceMetrics,
+    indexer: &I,
+    filter_preference: bool,
+) -> Result<RefreshOutcome>
+where
+    S: RefreshStorage + Sync,
+    I: RefreshIndexer + Sync,
+{
+    let fetch_result = fetcher
+        .fetch_with_cache(
+            &resolution.final_url,
+            existing_metadata.etag.as_deref(),
+            existing_metadata.last_modified.as_deref(),
+        )
+        .await?;
+
+    match fetch_result {
+        FetchResult::NotModified { .. } => {
+            if existing_metadata.filter_non_english.unwrap_or(true) != filter_preference {
+                let mut updated_metadata = existing_metadata.clone();
+                updated_metadata.filter_non_english = Some(filter_preference);
+                storage.save_metadata(alias, &updated_metadata)?;
+            }
+            Ok(RefreshOutcome::Unchanged {
+                alias: alias.to_string(),
+            })
+        },
+        FetchResult::Modified {
+            content,
+            sha256,
+            etag,
+            last_modified,
+        } => {
+            let payload = RefreshPayload {
+                content,
+                sha256,
+                etag,
+                last_modified,
+            };
+
+            let mut updated_metadata = existing_metadata.clone();
+            updated_metadata.url.clone_from(&resolution.final_url);
+            updated_metadata.variant = resolution.variant.clone();
+            updated_metadata.filter_non_english = Some(filter_preference);
+
+            apply_refresh(
+                storage,
+                alias,
+                updated_metadata,
+                existing_aliases,
+                payload,
+                metrics,
+                indexer,
+            )
+        },
+    }
+}
+
+/// Re-parse and re-index a source using cached content.
+pub fn reindex_source<S, I>(
+    storage: &S,
+    alias: &str,
+    metrics: PerformanceMetrics,
+    indexer: &I,
+    filter_preference: bool,
+) -> Result<ReindexOutcome>
+where
+    S: RefreshStorage,
+    I: RefreshIndexer,
+{
+    let content = storage.load_llms_txt(alias)?;
+    let mut parser = MarkdownParser::new()?;
+    let mut parse_result = parser.parse(&content)?;
+
+    let before_count = parse_result.heading_blocks.len();
+    apply_language_filter(&mut parse_result, filter_preference);
+    let after_count = parse_result.heading_blocks.len();
+
+    let index_path = storage.index_path(alias)?;
+    indexer.index(
+        alias,
+        index_path.as_path(),
+        metrics,
+        &parse_result.heading_blocks,
+    )?;
+
+    Ok(ReindexOutcome {
+        alias: alias.to_string(),
+        headings_before: before_count,
+        headings_after: after_count,
+        filtered: before_count.saturating_sub(after_count),
+    })
+}
+
+/// Apply a refresh: persist content and re-index the source.
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_lines)]
+pub fn apply_refresh<S, I>(
+    storage: &S,
+    alias: &str,
+    existing_metadata: Source,
+    existing_aliases: Vec<String>,
+    payload: RefreshPayload,
+    metrics: PerformanceMetrics,
+    indexer: &I,
+) -> Result<RefreshOutcome>
+where
+    S: RefreshStorage,
+    I: RefreshIndexer,
+{
+    let mut parser = MarkdownParser::new()?;
+    let mut parse_result = parser.parse(&payload.content)?;
+
+    let filter_enabled = existing_metadata.filter_non_english.unwrap_or(true);
+    let filter_stats = Some(apply_language_filter(&mut parse_result, filter_enabled));
+
+    storage.save_llms_txt(alias, &payload.content)?;
+
+    let mut llms_json = build_llms_json(
+        alias,
+        &existing_metadata.url,
+        "llms.txt",
+        payload.sha256.clone(),
+        payload.etag.clone(),
+        payload.last_modified.clone(),
+        &parse_result,
+    );
+
+    let mut metadata_aliases = existing_aliases;
+    for alias_value in &existing_metadata.aliases {
+        if !metadata_aliases.contains(alias_value) {
+            metadata_aliases.push(alias_value.clone());
+        }
+    }
+    metadata_aliases.sort();
+    metadata_aliases.dedup();
+    llms_json.metadata.aliases = metadata_aliases;
+    llms_json.metadata.tags.clone_from(&existing_metadata.tags);
+    llms_json
+        .metadata
+        .description
+        .clone_from(&existing_metadata.description);
+    llms_json
+        .metadata
+        .category
+        .clone_from(&existing_metadata.category);
+    llms_json
+        .metadata
+        .npm_aliases
+        .clone_from(&existing_metadata.npm_aliases);
+    llms_json
+        .metadata
+        .github_aliases
+        .clone_from(&existing_metadata.github_aliases);
+    llms_json.metadata.variant = existing_metadata.variant.clone();
+    llms_json.filter_stats = filter_stats;
+
+    storage.save_llms_json(alias, &llms_json)?;
+
+    let mut origin = existing_metadata.origin.clone();
+    origin.source_type = match (&origin.source_type, &existing_metadata.origin.source_type) {
+        (Some(SourceType::Remote { .. }), _) | (None, None) => Some(SourceType::Remote {
+            url: existing_metadata.url.clone(),
+        }),
+        (Some(SourceType::LocalFile { path }), _) => {
+            Some(SourceType::LocalFile { path: path.clone() })
+        },
+        (None, Some(existing)) => Some(existing.clone()),
+    };
+
+    llms_json.metadata.origin = origin.clone();
+
+    let metadata = Source {
+        url: existing_metadata.url,
+        etag: payload.etag,
+        last_modified: payload.last_modified,
+        fetched_at: chrono::Utc::now(),
+        sha256: payload.sha256,
+        variant: existing_metadata.variant,
+        aliases: existing_metadata.aliases,
+        tags: existing_metadata.tags,
+        description: existing_metadata.description,
+        category: existing_metadata.category,
+        npm_aliases: existing_metadata.npm_aliases,
+        github_aliases: existing_metadata.github_aliases,
+        origin,
+        filter_non_english: existing_metadata.filter_non_english,
+    };
+    storage.save_metadata(alias, &metadata)?;
+
+    let index_path = storage.index_path(alias)?;
+    indexer.index(
+        alias,
+        index_path.as_path(),
+        metrics,
+        &parse_result.heading_blocks,
+    )?;
+
+    Ok(RefreshOutcome::Refreshed {
+        alias: alias.to_string(),
+        headings: count_headings(&llms_json.toc),
+        lines: llms_json.line_index.total_lines,
+    })
+}
+
+fn apply_language_filter(
+    parse_result: &mut ParseResult,
+    filter_enabled: bool,
+) -> HeadingFilterStats {
+    let original_count = parse_result.heading_blocks.len();
+    if filter_enabled {
+        let mut language_filter = LanguageFilter::new(true);
+        parse_result.heading_blocks.retain(|block| {
+            let urls_in_content = extract_urls_from_content(&block.content);
+            let url_check = urls_in_content.is_empty()
+                || urls_in_content
+                    .iter()
+                    .all(|url| language_filter.is_english_url(url));
+
+            let heading_check = language_filter.is_english_heading_path(&block.path);
+
+            url_check && heading_check
+        });
+    }
+
+    let accepted = parse_result.heading_blocks.len();
+    let filtered_count = original_count.saturating_sub(accepted);
+    HeadingFilterStats {
+        enabled: filter_enabled,
+        headings_total: original_count,
+        headings_accepted: accepted,
+        headings_rejected: filtered_count,
+        reason: if filter_enabled {
+            "non-English content removed".to_string()
+        } else {
+            "filtering disabled".to_string()
+        },
+    }
+}
+
+fn count_headings(entries: &[TocEntry]) -> usize {
+    entries
+        .iter()
+        .map(|entry| 1 + count_headings(&entry.children))
+        .sum()
+}
+
+fn extract_urls_from_content(content: &str) -> Vec<String> {
+    let mut urls = Vec::new();
+
+    let mut search_start = 0;
+    while let Some(rel) = content[search_start..].find('[') {
+        let open_idx = search_start + rel;
+        if let Some(close_rel) = content[open_idx + 1..].find(']') {
+            let close_idx = open_idx + 1 + close_rel;
+            let after_bracket = content.get(close_idx + 1..).unwrap_or("");
+            if let Some(rest) = after_bracket.strip_prefix('(') {
+                if let Some(paren_rel) = rest.find(')') {
+                    if let Some(cleaned) = clean_url_slice(&rest[..paren_rel]) {
+                        urls.push(cleaned.to_string());
+                    }
+                }
+            }
+        }
+        search_start = open_idx + 1;
+    }
+
+    urls
+}
+
+fn clean_url_slice(s: &str) -> Option<&str> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let trimmed = trimmed
+        .strip_prefix('"')
+        .or_else(|| trimmed.strip_prefix('\''))
+        .unwrap_or(trimmed);
+
+    let trimmed = trimmed
+        .strip_suffix('"')
+        .or_else(|| trimmed.strip_suffix('\''))
+        .unwrap_or(trimmed);
+
+    let mut end = trimmed.len();
+    for (idx, ch) in trimmed.char_indices().rev() {
+        if trailing_punctuation(ch) {
+            end = idx;
+        } else {
+            break;
+        }
+    }
+
+    if end == 0 {
+        None
+    } else {
+        Some(&trimmed[..end])
+    }
+}
+
+const fn trailing_punctuation(c: char) -> bool {
+    matches!(c, ',' | '.' | ';' | ':' | '!' | '?')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    use anyhow::Result;
+
+    #[derive(Default)]
+    struct MockStorage {
+        metadata: HashMap<String, Source>,
+        saved_txt: RefCell<Vec<String>>,
+        saved_json: RefCell<Vec<String>>,
+        saved_metadata: RefCell<Vec<Source>>,
+        index_paths: HashMap<String, PathBuf>,
+        cached_txt: HashMap<String, String>,
+    }
+
+    impl RefreshStorage for MockStorage {
+        fn load_metadata(&self, alias: &str) -> crate::Result<Source> {
+            self.metadata
+                .get(alias)
+                .cloned()
+                .ok_or_else(|| crate::Error::NotFound("missing metadata".to_string()))
+        }
+
+        fn load_llms_aliases(&self, _alias: &str) -> crate::Result<Vec<String>> {
+            Ok(Vec::new())
+        }
+
+        fn save_llms_txt(&self, alias: &str, _content: &str) -> crate::Result<()> {
+            self.saved_txt.borrow_mut().push(alias.to_string());
+            Ok(())
+        }
+
+        fn save_llms_json(&self, alias: &str, _data: &crate::LlmsJson) -> crate::Result<()> {
+            self.saved_json.borrow_mut().push(alias.to_string());
+            Ok(())
+        }
+
+        fn save_metadata(&self, _alias: &str, metadata: &Source) -> crate::Result<()> {
+            self.saved_metadata.borrow_mut().push(metadata.clone());
+            Ok(())
+        }
+
+        fn index_path(&self, alias: &str) -> crate::Result<PathBuf> {
+            self.index_paths
+                .get(alias)
+                .cloned()
+                .ok_or_else(|| crate::Error::NotFound("missing index path".to_string()))
+        }
+
+        fn load_llms_txt(&self, alias: &str) -> crate::Result<String> {
+            self.cached_txt
+                .get(alias)
+                .cloned()
+                .ok_or_else(|| crate::Error::NotFound(format!("missing llms.txt for {alias}")))
+        }
+    }
+
+    #[derive(Default)]
+    struct MockIndexer {
+        indexed: RefCell<Vec<String>>,
+    }
+
+    impl RefreshIndexer for MockIndexer {
+        fn index(
+            &self,
+            alias: &str,
+            _index_path: &std::path::Path,
+            _metrics: PerformanceMetrics,
+            _blocks: &[crate::HeadingBlock],
+        ) -> crate::Result<()> {
+            self.indexed.borrow_mut().push(alias.to_string());
+            Ok(())
+        }
+    }
+
+    fn sample_source() -> Source {
+        Source {
+            url: "https://example.com/llms.txt".to_string(),
+            etag: None,
+            last_modified: None,
+            fetched_at: chrono::Utc::now(),
+            sha256: "abc123".to_string(),
+            variant: crate::SourceVariant::Llms,
+            aliases: Vec::new(),
+            tags: Vec::new(),
+            description: None,
+            category: None,
+            npm_aliases: Vec::new(),
+            github_aliases: Vec::new(),
+            origin: crate::SourceOrigin {
+                manifest: None,
+                source_type: Some(SourceType::Remote {
+                    url: "https://example.com/llms.txt".to_string(),
+                }),
+            },
+            filter_non_english: Some(true),
+        }
+    }
+
+    fn sample_payload() -> RefreshPayload {
+        RefreshPayload {
+            content: "# Title\n\nSome content.\n".to_string(),
+            sha256: "abc123".to_string(),
+            etag: None,
+            last_modified: None,
+        }
+    }
+
+    #[test]
+    fn apply_refresh_persists_changes() -> Result<()> {
+        let mut storage = MockStorage::default();
+        storage.metadata.insert("test".to_string(), sample_source());
+        storage
+            .index_paths
+            .insert("test".to_string(), PathBuf::from("index"));
+
+        let indexer = MockIndexer::default();
+        let outcome = apply_refresh(
+            &storage,
+            "test",
+            sample_source(),
+            Vec::new(),
+            sample_payload(),
+            PerformanceMetrics::default(),
+            &indexer,
+        )?;
+
+        assert!(matches!(outcome, RefreshOutcome::Refreshed { .. }));
+        assert_eq!(storage.saved_txt.borrow().len(), 1);
+        assert_eq!(storage.saved_json.borrow().len(), 1);
+        assert_eq!(storage.saved_metadata.borrow().len(), 1);
+        assert_eq!(indexer.indexed.borrow().len(), 1);
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- extract refresh/reindex helpers into blz-core for reuse across CLI + MCP
- centralize refresh result handling and metadata mapping

## Testing
- Not run (covered by upstack changes).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured core library organization to centralize shared utilities.
  * Optimized module dependencies across CLI components.

* **New Features**
  * Added user notifications to inform about configuration file updates.

* **Chores**
  * Updated project configuration and documentation for BLZ integration guidelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->