### PR TITLE
refactor(mcp): add blz tool for source actions

### DIFF
--- a/crates/blz-mcp/data/learn_blz.json
+++ b/crates/blz-mcp/data/learn_blz.json
@@ -14,17 +14,17 @@
     {
       "name": "Search and retrieve",
       "steps": [
-        "Use blz_find tool with query to search documentation",
+        "Use find tool with action 'search' to search documentation",
         "Review search results to identify relevant citations",
-        "Use blz_find tool with snippets parameter to retrieve full content"
+        "Use find tool with action 'get' to retrieve full content"
       ]
     },
     {
       "name": "Add new source",
       "steps": [
-        "Use blz_list_sources to check if source is in registry",
-        "Use blz_add_source with alias to install from registry",
-        "Or use blz_add_source with alias and url for custom sources"
+        "Use blz tool with action 'list' to check if source is in the registry",
+        "Use blz tool with action 'add' to install from the registry",
+        "Or use blz tool with action 'add' and url for custom sources"
       ]
     }
   ],
@@ -32,14 +32,15 @@
     "Always specify a source filter when searching for best performance",
     "Use context_mode='symmetric' with line_padding=5 for code examples",
     "Use context_mode='all' to retrieve entire documentation sections",
-    "Check blz_list_sources before adding to avoid duplicates",
+    "Check blz action 'list' before adding to avoid duplicates",
     "Citations format: 'source:start-end' or 'source:range1,range2' for multiple ranges"
   ],
   "examples": [
     {
       "description": "Search for async patterns in Bun docs",
-      "tool": "blz_find",
+      "tool": "find",
       "params": {
+        "action": "search",
         "query": "async await",
         "source": "bun",
         "maxResults": 5
@@ -47,8 +48,9 @@
     },
     {
       "description": "Retrieve code example with context",
-      "tool": "blz_find",
+      "tool": "find",
       "params": {
+        "action": "get",
         "snippets": ["bun:1234-1250"],
         "contextMode": "symmetric",
         "linePadding": 5
@@ -56,22 +58,24 @@
     },
     {
       "description": "List all installed sources",
-      "tool": "blz_list_sources",
+      "tool": "blz",
       "params": {
+        "action": "list",
         "kind": "installed"
       }
     },
     {
       "description": "Add React documentation",
-      "tool": "blz_add_source",
+      "tool": "blz",
       "params": {
+        "action": "add",
         "alias": "react"
       }
     }
   ],
   "cli_equivalents": {
-    "find_search": "blz search 'query' --source bun --json",
-    "find_retrieve": "blz get bun:100-200 -C 5 --json",
+    "find_search": "blz find \"async await\" --source bun --json",
+    "find_retrieve": "blz find \"bun:100-200\" -C 5 --json",
     "list_sources": "blz list --json",
     "source_add": "blz add react https://react.dev/llms.txt"
   }

--- a/crates/blz-mcp/src/prompts/discover.rs
+++ b/crates/blz-mcp/src/prompts/discover.rs
@@ -30,7 +30,7 @@ pub struct DiscoverDocsOutput {
 /// Three-step flow:
 /// 1. List matching installed sources
 /// 2. Surface registry-only entries (sources in registry but not installed)
-/// 3. Suggest `blz_find` tool usage for installed sources
+/// 3. Suggest `find` tool usage for installed sources
 ///
 /// Cap output at 3 messages total.
 #[tracing::instrument(skip(storage))]
@@ -116,28 +116,27 @@ pub fn handle_discover_docs(
             .collect::<Vec<_>>()
             .join("\n");
 
-        let add_command = registry_only
+        let add_example = registry_only
             .first()
-            .map(|(slug, _, _)| format!("blz add {slug}"))
+            .map(|(slug, _, _)| slug.clone())
             .unwrap_or_default();
 
         messages.push(PromptMessage::new_text(
             PromptMessageRole::Assistant,
             format!(
-                "Found {} source(s) in the registry (not yet installed):\n\n{}\n\nTo add a source, use the `blz_add_source` tool or run: `{}`",
+                "Found {} source(s) in the registry (not yet installed):\n\n{}\n\nTo add a source, use the `blz` tool:\n\n```json\n{{\n  \"action\": \"add\",\n  \"alias\": \"{add_example}\"\n}}\n```\n\nOr run: `blz add {add_example}`",
                 registry_only.len(),
                 registry_list,
-                add_command
             ),
         ));
     }
 
-    // Step 3: Suggest `blz_find` tool usage for installed sources
+    // Step 3: Suggest `find` tool usage for installed sources
     if let Some(example_source) = installed_sources.first() {
         messages.push(PromptMessage::new_text(
             PromptMessageRole::Assistant,
             format!(
-                "To search within installed sources, use the `blz_find` tool:\n\n```json\n{{\n  \"query\": \"your search query\",\n  \"source\": \"{example_source}\"\n}}\n```"
+                "To search within installed sources, use the `find` tool:\n\n```json\n{{\n  \"action\": \"search\",\n  \"query\": \"your search query\",\n  \"source\": \"{example_source}\"\n}}\n```"
             ),
         ));
     } else if registry_only.is_empty() {
@@ -145,7 +144,7 @@ pub fn handle_discover_docs(
         messages.push(PromptMessage::new_text(
             PromptMessageRole::Assistant,
             format!(
-                "No documentation sources found for: {}\n\nTry different technology names or check the registry with the `blz_list_sources` tool.",
+                "No documentation sources found for: {}\n\nTry different technology names or check the registry with the `blz` tool:\n\n```json\n{{\n  \"action\": \"list\",\n  \"kind\": \"registry\"\n}}\n```",
                 params.technologies
             ),
         ));

--- a/crates/blz-mcp/src/tools/blz.rs
+++ b/crates/blz-mcp/src/tools/blz.rs
@@ -1,0 +1,689 @@
+//! Unified BLZ tool for source management and metadata actions.
+
+use std::fs;
+
+use blz_core::refresh::{
+    DefaultRefreshIndexer, RefreshOutcome, RefreshStorage, refresh_source_with_metadata,
+    reindex_source, resolve_refresh_url,
+};
+use blz_core::{Fetcher, HeadingFilterStats, PerformanceMetrics, Storage, TocEntry};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    cache,
+    error::{McpError, McpResult},
+    types::IndexCache,
+};
+
+use super::{
+    learn_blz::{LearnBlzParams, handle_learn_blz},
+    run_command::{RunCommandOutput, RunCommandParams, handle_run_command},
+    sources::{
+        ListSourcesOutput, ListSourcesParams, SourceAddOutput, SourceAddParams,
+        handle_list_sources, handle_source_add,
+    },
+};
+
+/// Parameters for blz tool
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlzParams {
+    /// Action to execute
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action: Option<BlzAction>,
+
+    /// Source alias (for add/remove/refresh/info/validate/history)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alias: Option<String>,
+
+    /// URL override (for add)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+
+    /// Force override if source exists (for add)
+    #[serde(default)]
+    pub force: bool,
+
+    /// Filter for list (installed/registry/all)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+
+    /// Query filter for list
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query: Option<String>,
+
+    /// Re-index instead of fetching (for refresh)
+    #[serde(default)]
+    pub reindex: bool,
+
+    /// Refresh all sources
+    #[serde(default)]
+    pub all: bool,
+}
+
+/// Supported blz actions
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum BlzAction {
+    /// List sources (installed/registry/all)
+    List,
+    /// Add a source to the cache
+    Add,
+    /// Remove a source and cached data
+    Remove,
+    /// Refresh cached sources
+    Refresh,
+    /// Show detailed info for a source
+    Info,
+    /// Validate source data integrity
+    Validate,
+    /// Show archive history for a source
+    History,
+    /// Return help and usage guidance
+    Help,
+}
+
+/// Output from blz tool
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlzOutput {
+    /// Action that was executed
+    pub action: BlzAction,
+
+    /// List output
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub list: Option<ListSourcesOutput>,
+
+    /// Add output
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub add: Option<SourceAddOutput>,
+
+    /// Remove output
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remove: Option<RemoveOutput>,
+
+    /// Refresh output
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh: Option<RefreshSummary>,
+
+    /// Info output
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub info: Option<SourceInfoOutput>,
+
+    /// Validate output
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub validate: Option<RunCommandOutput>,
+
+    /// History output
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub history: Option<RunCommandOutput>,
+
+    /// Help output
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help: Option<Value>,
+}
+
+/// Summary information for removals
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoveOutput {
+    /// Alias that was removed
+    pub alias: String,
+    /// Human-readable removal summary
+    pub message: String,
+    /// Optional removal metadata
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub info: Option<RemovalInfo>,
+}
+
+/// Removal metadata
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemovalInfo {
+    /// Canonical alias removed
+    pub alias: String,
+    /// Source URL
+    pub url: String,
+    /// Total line count at removal time
+    pub total_lines: usize,
+    /// Last fetched timestamp (RFC3339)
+    pub fetched_at: String,
+}
+
+/// Detailed source info output
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceInfoOutput {
+    /// Canonical source alias
+    pub alias: String,
+    /// Source URL
+    pub url: String,
+    /// Variant (llms, llms-full, custom)
+    pub variant: String,
+    /// Additional alias names
+    pub aliases: Vec<String>,
+    /// Total lines in cached content
+    pub lines: usize,
+    /// Total headings in the TOC
+    pub headings: usize,
+    /// Size of cached content in bytes
+    pub size_bytes: u64,
+    /// Last updated timestamp (RFC3339)
+    pub last_updated: Option<String>,
+    /// `ETag` value if present
+    pub etag: Option<String>,
+    /// SHA256 checksum if available
+    pub checksum: Option<String>,
+    /// Local cache directory path
+    pub cache_path: String,
+    /// Language filter statistics
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter_stats: Option<HeadingFilterStats>,
+}
+
+/// Refresh summary for one or more sources
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RefreshSummary {
+    /// Per-source refresh results
+    pub results: Vec<RefreshResult>,
+    /// Count of refreshed sources
+    pub refreshed: usize,
+    /// Count of unchanged sources
+    pub unchanged: usize,
+    /// Count of reindexed sources
+    pub reindexed: usize,
+    /// Count of failures
+    pub errors: usize,
+}
+
+/// Per-source refresh result
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RefreshResult {
+    /// Source alias
+    pub alias: String,
+    /// Refresh status
+    pub status: RefreshStatus,
+    /// Heading count (refresh only)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headings: Option<usize>,
+    /// Line count (refresh only)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lines: Option<usize>,
+    /// Heading count before reindex
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headings_before: Option<usize>,
+    /// Heading count after reindex
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headings_after: Option<usize>,
+    /// Number of headings filtered during reindex
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filtered: Option<usize>,
+    /// Error message if refresh failed
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+/// Refresh status values
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RefreshStatus {
+    /// Source content refreshed and re-indexed
+    Refreshed,
+    /// Source content unchanged
+    Unchanged,
+    /// Source reindexed without fetching
+    Reindexed,
+    /// Refresh failed
+    Error,
+}
+
+const fn empty_output(action: BlzAction) -> BlzOutput {
+    BlzOutput {
+        action,
+        list: None,
+        add: None,
+        remove: None,
+        refresh: None,
+        info: None,
+        validate: None,
+        history: None,
+        help: None,
+    }
+}
+
+const fn resolve_action(params: &BlzParams) -> BlzAction {
+    if let Some(action) = params.action {
+        return action;
+    }
+
+    if params.url.is_some() || params.force {
+        return BlzAction::Add;
+    }
+
+    if params.reindex || params.all {
+        return BlzAction::Refresh;
+    }
+
+    if params.alias.is_some() {
+        return BlzAction::Info;
+    }
+
+    BlzAction::List
+}
+
+fn resolve_alias(storage: &Storage, requested: &str) -> McpResult<Option<String>> {
+    let requested_str = requested.to_string();
+    let known = storage.list_sources();
+
+    if known.iter().any(|alias| alias == requested) {
+        return Ok(Some(requested_str));
+    }
+
+    let mut resolved_sources = Vec::new();
+    for source in &known {
+        if let Ok(Some(metadata)) = storage.load_source_metadata(source) {
+            if metadata.aliases.iter().any(|alias| alias == requested) {
+                resolved_sources.push(source.clone());
+                continue;
+            }
+        }
+
+        if let Ok(llms) = storage.load_llms_json(source) {
+            if llms.metadata.aliases.iter().any(|alias| alias == requested) {
+                resolved_sources.push(source.clone());
+            }
+        }
+    }
+
+    match resolved_sources.len() {
+        0 => Ok(None),
+        1 => Ok(resolved_sources.pop()),
+        _ => Err(McpError::InvalidParams(format!(
+            "Alias '{}' is ambiguous across multiple sources: {}",
+            requested,
+            resolved_sources.join(", ")
+        ))),
+    }
+}
+
+fn resolve_required_alias(
+    storage: &Storage,
+    alias: Option<String>,
+    action: BlzAction,
+) -> McpResult<String> {
+    let alias = alias.ok_or_else(|| McpError::MissingParameter("alias".to_string()))?;
+    let resolved = resolve_alias(storage, &alias)?.ok_or_else(|| {
+        McpError::SourceNotFound(format!(
+            "No source found for '{alias}' (required for {action:?})"
+        ))
+    })?;
+    Ok(resolved)
+}
+
+fn remove_source(storage: &Storage, alias: &str) -> McpResult<RemoveOutput> {
+    if !storage.exists(alias) {
+        return Err(McpError::SourceNotFound(alias.to_string()));
+    }
+
+    let info = storage.load_llms_json(alias).ok().map(|llms| RemovalInfo {
+        alias: alias.to_string(),
+        url: llms.metadata.url.clone(),
+        total_lines: llms.line_index.total_lines,
+        fetched_at: llms.metadata.fetched_at.to_rfc3339(),
+    });
+
+    let dir = storage.tool_dir(alias)?;
+    fs::remove_dir_all(&dir).map_err(|e| {
+        McpError::Internal(format!(
+            "Failed to remove source directory '{}': {e}",
+            dir.display()
+        ))
+    })?;
+    storage.remove_descriptor(alias)?;
+
+    Ok(RemoveOutput {
+        alias: alias.to_string(),
+        message: format!("Removed source '{alias}' and cached data"),
+        info,
+    })
+}
+
+fn count_headings(entries: &[TocEntry]) -> usize {
+    entries
+        .iter()
+        .map(|entry| 1 + count_headings(&entry.children))
+        .sum()
+}
+
+fn load_info(storage: &Storage, alias: &str) -> McpResult<SourceInfoOutput> {
+    if !storage.exists(alias) {
+        return Err(McpError::SourceNotFound(alias.to_string()));
+    }
+
+    let llms = storage.load_llms_json(alias)?;
+    let metadata = llms.metadata.clone();
+    let llms_path = storage.llms_txt_path(alias)?;
+    let file_metadata = fs::metadata(&llms_path).map_err(|e| {
+        McpError::Internal(format!("Failed to read source file for '{alias}': {e}"))
+    })?;
+    let cache_path = storage.tool_dir(alias)?.to_string_lossy().to_string();
+
+    Ok(SourceInfoOutput {
+        alias: alias.to_string(),
+        url: metadata.url.clone(),
+        variant: format!("{:?}", metadata.variant),
+        aliases: metadata.aliases.clone(),
+        lines: llms.line_index.total_lines,
+        headings: count_headings(&llms.toc),
+        size_bytes: file_metadata.len(),
+        last_updated: Some(metadata.fetched_at.to_rfc3339()),
+        etag: metadata.etag.clone(),
+        checksum: Some(metadata.sha256),
+        cache_path,
+        filter_stats: llms.filter_stats,
+    })
+}
+
+async fn refresh_one(
+    storage: &Storage,
+    index_cache: &IndexCache,
+    fetcher: &Fetcher,
+    alias: &str,
+    metrics: PerformanceMetrics,
+    indexer: &DefaultRefreshIndexer,
+) -> McpResult<RefreshResult> {
+    let metadata = storage.load_metadata(alias)?;
+    let aliases = storage.load_llms_aliases(alias)?;
+    let filter_preference = metadata.filter_non_english.unwrap_or(true);
+
+    let resolution = resolve_refresh_url(fetcher, &metadata).await?;
+    let outcome = refresh_source_with_metadata(
+        storage,
+        fetcher,
+        alias,
+        metadata,
+        aliases,
+        &resolution,
+        metrics,
+        indexer,
+        filter_preference,
+    )
+    .await?;
+
+    cache::invalidate_cache(index_cache, alias).await;
+
+    match outcome {
+        RefreshOutcome::Refreshed {
+            alias,
+            headings,
+            lines,
+        } => Ok(RefreshResult {
+            alias,
+            status: RefreshStatus::Refreshed,
+            headings: Some(headings),
+            lines: Some(lines),
+            headings_before: None,
+            headings_after: None,
+            filtered: None,
+            message: None,
+        }),
+        RefreshOutcome::Unchanged { alias } => Ok(RefreshResult {
+            alias,
+            status: RefreshStatus::Unchanged,
+            headings: None,
+            lines: None,
+            headings_before: None,
+            headings_after: None,
+            filtered: None,
+            message: None,
+        }),
+    }
+}
+
+async fn reindex_one(
+    storage: &Storage,
+    index_cache: &IndexCache,
+    alias: &str,
+    metrics: PerformanceMetrics,
+    indexer: &DefaultRefreshIndexer,
+) -> McpResult<RefreshResult> {
+    let metadata = storage.load_metadata(alias)?;
+    let filter_preference = metadata.filter_non_english.unwrap_or(true);
+    let outcome = reindex_source(storage, alias, metrics, indexer, filter_preference)?;
+
+    cache::invalidate_cache(index_cache, alias).await;
+
+    Ok(RefreshResult {
+        alias: outcome.alias,
+        status: RefreshStatus::Reindexed,
+        headings: None,
+        lines: None,
+        headings_before: Some(outcome.headings_before),
+        headings_after: Some(outcome.headings_after),
+        filtered: Some(outcome.filtered),
+        message: None,
+    })
+}
+
+async fn refresh_sources(
+    storage: &Storage,
+    index_cache: &IndexCache,
+    alias: Option<String>,
+    all: bool,
+    reindex: bool,
+) -> McpResult<RefreshSummary> {
+    if all && alias.is_some() {
+        return Err(McpError::InvalidParams(
+            "Provide either 'alias' or 'all', not both".to_string(),
+        ));
+    }
+
+    let targets = if all {
+        let sources = storage.list_sources();
+        if sources.is_empty() {
+            return Err(McpError::InvalidParams(
+                "No sources available to refresh".to_string(),
+            ));
+        }
+        sources
+    } else {
+        let alias = resolve_required_alias(storage, alias, BlzAction::Refresh)?;
+        vec![alias]
+    };
+
+    let fetcher = Fetcher::new()?;
+    let indexer = DefaultRefreshIndexer;
+    let metrics = PerformanceMetrics::default();
+
+    let mut results = Vec::new();
+    let mut refreshed = 0;
+    let mut unchanged = 0;
+    let mut reindexed = 0;
+    let mut errors = 0;
+
+    for alias in targets {
+        let result = if reindex {
+            reindex_one(storage, index_cache, &alias, metrics.clone(), &indexer).await
+        } else {
+            refresh_one(
+                storage,
+                index_cache,
+                &fetcher,
+                &alias,
+                metrics.clone(),
+                &indexer,
+            )
+            .await
+        };
+
+        match result {
+            Ok(entry) => {
+                match entry.status {
+                    RefreshStatus::Refreshed => refreshed += 1,
+                    RefreshStatus::Unchanged => unchanged += 1,
+                    RefreshStatus::Reindexed => reindexed += 1,
+                    RefreshStatus::Error => errors += 1,
+                }
+                results.push(entry);
+            },
+            Err(e) => {
+                errors += 1;
+                results.push(RefreshResult {
+                    alias,
+                    status: RefreshStatus::Error,
+                    headings: None,
+                    lines: None,
+                    headings_before: None,
+                    headings_after: None,
+                    filtered: None,
+                    message: Some(e.to_string()),
+                });
+            },
+        }
+    }
+
+    Ok(RefreshSummary {
+        results,
+        refreshed,
+        unchanged,
+        reindexed,
+        errors,
+    })
+}
+
+async fn handle_list_action(
+    kind: Option<String>,
+    query: Option<String>,
+    storage: &Storage,
+) -> McpResult<BlzOutput> {
+    let list_params = ListSourcesParams { kind, query };
+    let output = handle_list_sources(list_params, storage).await?;
+    let mut response = empty_output(BlzAction::List);
+    response.list = Some(output);
+    Ok(response)
+}
+
+async fn handle_add_action(
+    alias: Option<String>,
+    url: Option<String>,
+    force: bool,
+    storage: &Storage,
+    index_cache: &IndexCache,
+) -> McpResult<BlzOutput> {
+    let alias = alias.ok_or_else(|| McpError::MissingParameter("alias".to_string()))?;
+    let add_params = SourceAddParams { alias, url, force };
+    let output = handle_source_add(add_params, storage, index_cache).await?;
+    let mut response = empty_output(BlzAction::Add);
+    response.add = Some(output);
+    Ok(response)
+}
+
+async fn handle_remove_action(
+    alias: Option<String>,
+    storage: &Storage,
+    index_cache: &IndexCache,
+) -> McpResult<BlzOutput> {
+    let alias = resolve_required_alias(storage, alias, BlzAction::Remove)?;
+    let output = remove_source(storage, &alias)?;
+    cache::invalidate_cache(index_cache, &alias).await;
+    let mut response = empty_output(BlzAction::Remove);
+    response.remove = Some(output);
+    Ok(response)
+}
+
+async fn handle_refresh_action(
+    alias: Option<String>,
+    all: bool,
+    reindex: bool,
+    storage: &Storage,
+    index_cache: &IndexCache,
+) -> McpResult<BlzOutput> {
+    let output = refresh_sources(storage, index_cache, alias, all, reindex).await?;
+    let mut response = empty_output(BlzAction::Refresh);
+    response.refresh = Some(output);
+    Ok(response)
+}
+
+fn handle_info_action(alias: Option<String>, storage: &Storage) -> McpResult<BlzOutput> {
+    let alias = resolve_required_alias(storage, alias, BlzAction::Info)?;
+    let output = load_info(storage, &alias)?;
+    let mut response = empty_output(BlzAction::Info);
+    response.info = Some(output);
+    Ok(response)
+}
+
+async fn handle_validate_action(alias: Option<String>, storage: &Storage) -> McpResult<BlzOutput> {
+    let resolved = match alias {
+        Some(value) => resolve_alias(storage, &value)?,
+        None => None,
+    };
+    let output = handle_run_command(
+        RunCommandParams {
+            command: "validate".to_string(),
+            source: resolved,
+        },
+        storage,
+    )
+    .await?;
+    let mut response = empty_output(BlzAction::Validate);
+    response.validate = Some(output);
+    Ok(response)
+}
+
+async fn handle_history_action(alias: Option<String>, storage: &Storage) -> McpResult<BlzOutput> {
+    let alias = resolve_required_alias(storage, alias, BlzAction::History)?;
+    let output = handle_run_command(
+        RunCommandParams {
+            command: "history".to_string(),
+            source: Some(alias),
+        },
+        storage,
+    )
+    .await?;
+    let mut response = empty_output(BlzAction::History);
+    response.history = Some(output);
+    Ok(response)
+}
+
+async fn handle_help_action() -> McpResult<BlzOutput> {
+    let output = handle_learn_blz(LearnBlzParams {}).await?;
+    let mut response = empty_output(BlzAction::Help);
+    response.help = Some(output.content);
+    Ok(response)
+}
+
+/// Main handler for blz tool
+#[tracing::instrument(skip(storage, index_cache))]
+pub async fn handle_blz(
+    params: BlzParams,
+    storage: &Storage,
+    index_cache: &IndexCache,
+) -> McpResult<BlzOutput> {
+    let action = resolve_action(&params);
+    let BlzParams {
+        alias,
+        url,
+        force,
+        kind,
+        query,
+        reindex,
+        all,
+        ..
+    } = params;
+
+    match action {
+        BlzAction::List => handle_list_action(kind, query, storage).await,
+        BlzAction::Add => handle_add_action(alias, url, force, storage, index_cache).await,
+        BlzAction::Remove => handle_remove_action(alias, storage, index_cache).await,
+        BlzAction::Refresh => {
+            handle_refresh_action(alias, all, reindex, storage, index_cache).await
+        },
+        BlzAction::Info => handle_info_action(alias, storage),
+        BlzAction::Validate => handle_validate_action(alias, storage).await,
+        BlzAction::History => handle_history_action(alias, storage).await,
+        BlzAction::Help => handle_help_action().await,
+    }
+}

--- a/crates/blz-mcp/src/tools/mod.rs
+++ b/crates/blz-mcp/src/tools/mod.rs
@@ -1,14 +1,10 @@
 //! MCP tools for BLZ
 
+pub mod blz;
 pub mod find;
-pub mod learn_blz;
-pub mod run_command;
-pub mod sources;
+mod learn_blz;
+mod run_command;
+mod sources;
 
+pub use blz::{BlzOutput, BlzParams, handle_blz};
 pub use find::{FindOutput, FindParams, handle_find};
-pub use learn_blz::{LearnBlzOutput, LearnBlzParams, handle_learn_blz};
-pub use run_command::{RunCommandOutput, RunCommandParams, handle_run_command};
-pub use sources::{
-    ListSourcesOutput, ListSourcesParams, SourceAddOutput, SourceAddParams, handle_list_sources,
-    handle_source_add,
-};


### PR DESCRIPTION
## Summary
- add a new `blz` MCP tool with action-based dispatch for source management
- consolidate add/remove/refresh/info/validate/history/help under one handler
- update discover prompt + learn payload to reflect the unified tool surface

## Testing
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized tool interfaces to use explicit action parameters for improved consistency and clarity
  * Unified registry management operations under a single consolidated tool
  * Simplified tool naming and parameter structure for more intuitive interaction

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->