### PR TITLE
docs(workflows): align version management with release-please

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -433,9 +433,10 @@ When modifying workflows:
 ### Version Management
 
 - Use semantic versioning strictly
-- Release labels determine bump type automatically
-- Canary releases include timestamp for uniqueness
-- Pre-releases skip Homebrew publishing
+- release-please automatically calculates version bumps from conventional commits and opens release PRs
+- Merge the release PR to create the tag + draft release; `publish.yml` handles publishing
+- Canary releases run from `release-canary` and publish with canary dist-tags
+- Pre-releases skip Homebrew publishing by default
 
 ### Security Considerations
 


### PR DESCRIPTION
## Summary
- replace legacy release-label wording with release-please flow notes
- clarify versioning and canary behavior for the current pipeline

## Testing
- Not run (docs-only change).
