### PR TITLE
perf(hooks): defer fetcher network tests to CI

### DIFF
--- a/crates/blz-core/src/fetcher.rs
+++ b/crates/blz-core/src/fetcher.rs
@@ -243,6 +243,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "network: run in CI"]
     async fn test_fetch_with_etag_not_modified() -> anyhow::Result<()> {
         // Setup mock server
         let mock_server = MockServer::start().await;
@@ -274,6 +275,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "network: run in CI"]
     async fn test_fetch_with_etag_modified() -> anyhow::Result<()> {
         // Setup mock server
         let mock_server = MockServer::start().await;
@@ -356,6 +358,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "network: run in CI"]
     async fn test_fetch_404_error() -> anyhow::Result<()> {
         // Setup mock server
         let mock_server = MockServer::start().await;
@@ -389,6 +392,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "network: run in CI"]
     async fn test_fetch_500_error() -> anyhow::Result<()> {
         // Setup mock server
         let mock_server = MockServer::start().await;
@@ -420,6 +424,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "network: run in CI"]
     async fn test_fetch_timeout() -> anyhow::Result<()> {
         // Setup mock server with very slow response
         let mock_server = MockServer::start().await;
@@ -453,6 +458,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "network: run in CI"]
     async fn test_fetch_simple_without_cache() -> anyhow::Result<()> {
         // Setup mock server
         let mock_server = MockServer::start().await;
@@ -536,6 +542,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "network: run in CI"]
     async fn test_invalid_urls() -> anyhow::Result<()> {
         let fetcher = Fetcher::new()?;
 
@@ -556,6 +563,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "network: run in CI"]
     async fn test_concurrent_requests() -> anyhow::Result<()> {
         // Setup mock server
         let mock_server = MockServer::start().await;

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -173,8 +173,8 @@ pre-push:
           else
             echo "💡 Tip: Install sccache for 2-3x faster builds: cargo install sccache"
           fi
-          # Run tests excluding slow compile-time UI tests (run those in CI)
-          # compile_fail_ui takes 120+ seconds and is marked #[ignore] - CI runs it separately
+          # Run tests excluding slow compile-time UI tests and ignored network tests (run those in CI)
+          # compile_fail_ui and fetcher wiremock tests are marked #[ignore] and run in CI
           if command -v cargo-nextest >/dev/null 2>&1; then
             # nextest runs tests in parallel, much faster
             echo "🧪 Running tests with cargo-nextest (parallel execution)..."


### PR DESCRIPTION
## Summary
- mark wiremock fetcher tests as ignored to keep pre-push fast
- keep CI coverage by running ignored tests in tests.yml
- clarify pre-push test notes in lefthook

## Testing
- Not run (changes are to test attributes + hook text only).

Closes #340.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Network-dependent integration tests are now configured to skip during continuous integration runs.

* **Chores**
  * Updated pre-push hook documentation to clarify test exclusion strategy, reflecting that both UI tests and network tests are excluded.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->