### PR TITLE
fix(add): improve llms.txt resolution guidance

### DIFF
--- a/crates/blz-cli/src/commands/add.rs
+++ b/crates/blz-cli/src/commands/add.rs
@@ -376,7 +376,8 @@ async fn fetch_and_index(
         spinner.finish_and_clear();
         eprintln!(
             "{} This appears to be a navigation index only ({} lines).\n\
-             BLZ works best with full documentation files (llms-full.txt).",
+             BLZ works best with full documentation files (llms-full.txt).\n\
+             If this is a hub or registry, add the downstream source URL instead.",
             "⚠".yellow(),
             resolved.line_count
         );


### PR DESCRIPTION
## Summary
- detect 401/403/429 HEAD responses and surface a clearer add error with guidance
- explain when a source looks like a hub/index and suggest adding downstream URLs

## Testing
- Not run (error message and warning adjustments only).

Closes #307.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages when URL resolution fails, providing clearer guidance on blocking statuses (401, 403, 429) versus other non-success responses.
  * Updated warning message for navigation index detection to include additional configuration guidance for hub and registry setups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->