### PR TITLE
fix(cli): improve shell completions and docs

### DIFF
--- a/crates/blz-cli/src/prompts/completions.prompt.json
+++ b/crates/blz-cli/src/prompts/completions.prompt.json
@@ -12,7 +12,7 @@
     }
   ],
   "agent_tips": [
-    "For dynamic completions (aliases, headings via `blz toc`) consider sourcing the helper scripts in `scripts/blz-*-init` after installing static completions.",
-    "When automating environment setup, pair this command with `install-dev.sh` or `cargo install` in a bootstrap script."
+    "For dynamic completions (aliases, headings via `blz toc`) source the helper scripts in `scripts/blz-dynamic-completions.(zsh|fish|ps1)` after installing static completions.",
+    "When automating environment setup, pair this command with `scripts/install-completions.sh` or `cargo install` in a bootstrap script."
   ]
 }

--- a/docs/cli/shell_integration.md
+++ b/docs/cli/shell_integration.md
@@ -6,9 +6,9 @@ Complete guide to shell completions and integration for BLZ.
 
 - [Supported Shells](#supported-shells)
 - [Quick Setup](#quick-setup)
-- [Bash](#bash)
 - [Zsh](#zsh)
 - [Fish](#fish)
+- [Bash](#bash)
 - [PowerShell](#powershell)
 - [Elvish](#elvish)
 - [Integration Examples](#integration-examples)
@@ -22,20 +22,13 @@ Complete guide to shell completions and integration for BLZ.
 
 BLZ provides completions for:
 
+- **Zsh** - Rich completions (default on macOS) with optional dynamic aliases
+- **Fish** - Dynamic alias/anchor completions via helper script
 - **Bash** - Standard completions with broad compatibility
-- **Zsh** - Rich completions with Oh My Zsh support
-- **Fish** - Best experience with dynamic source completion
-- **PowerShell** - Windows and cross-platform support
+- **PowerShell** - Windows and cross-platform support (static + optional dynamic aliases)
 - **Elvish** - Modern shell with structured data support
 
 ## Quick Setup
-
-### Bash
-
-```bash
-blz completions bash > ~/.local/share/bash-completion/completions/blz
-source ~/.bashrc
-```
 
 ### Zsh
 
@@ -54,10 +47,22 @@ blz completions fish > ~/.config/fish/completions/blz.fish
 source ~/.config/fish/config.fish
 ```
 
+### Bash
+
+```bash
+blz completions bash > ~/.local/share/bash-completion/completions/blz
+source ~/.bashrc
+```
+
 ### PowerShell
 
 ```powershell
-blz completions powershell >> $PROFILE
+$profileDir = Split-Path -Parent $PROFILE
+$completionFile = Join-Path $profileDir "blz-completions.ps1"
+blz completions powershell > $completionFile
+if (-not (Select-String -Path $PROFILE -Pattern $completionFile -Quiet)) {
+    Add-Content $PROFILE "if (Test-Path `"$completionFile`") { . `"$completionFile`" }"
+}
 . $PROFILE
 ```
 
@@ -67,84 +72,6 @@ blz completions powershell >> $PROFILE
 blz completions elvish > ~/.elvish/lib/blz.elv
 echo 'use blz' >> ~/.elvish/rc.elv
 exec elvish
-```
-
-## Bash
-
-Standard completions for commands and options.
-
-### Installation
-
-#### Linux
-
-```bash
-# Most distros - standard location
-blz completions bash | sudo tee /usr/share/bash-completion/completions/blz
-
-# User-specific (no sudo required)
-mkdir -p ~/.local/share/bash-completion/completions
-blz completions bash > ~/.local/share/bash-completion/completions/blz
-
-# Reload
-source ~/.bashrc
-```
-
-#### macOS
-
-```bash
-# Install bash-completion first
-brew install bash-completion@2
-
-# Add to ~/.bash_profile
-echo '[[ -r "$(brew --prefix)/etc/profile.d/bash_completion.sh" ]] && . "$(brew --prefix)/etc/profile.d/bash_completion.sh"' >> ~/.bash_profile
-
-# Install completions
-blz completions bash > $(brew --prefix)/etc/bash_completion.d/blz
-
-# Reload
-source ~/.bash_profile
-```
-
-### Features
-
-- Command completion
-- Option/flag completion
-- Filename completion for paths
-
-### Usage
-
-```bash
-blz <TAB><TAB>           # List commands
-blz search --<TAB><TAB>  # List options
-blz add <TAB><TAB>       # Complete filenames
-```
-
-### Troubleshooting
-
-#### Completions not working
-
-```bash
-# Check bash-completion is loaded
-type _init_completion
-
-# If not found, ensure bash-completion is installed
-# Then source it manually
-source /usr/share/bash-completion/bash_completion
-```
-
-#### Old Bash version
-
-Bash 3.x (macOS default) has limited completion support. Consider:
-
-```bash
-# Install newer Bash
-brew install bash
-
-# Add to /etc/shells
-echo $(brew --prefix)/bin/bash | sudo tee -a /etc/shells
-
-# Change default shell
-chsh -s $(brew --prefix)/bin/bash
 ```
 
 ## Zsh
@@ -194,7 +121,7 @@ rm -f ~/.zcompdump && compinit
 
 - Command completion with descriptions
 - Option completion
-- Basic argument completion
+- Dynamic alias/anchor completion (with helper script)
 
 ### Dynamic Alias Completion
 
@@ -208,7 +135,7 @@ source /path/to/blz/scripts/blz-dynamic-completions.zsh
 What it adds:
 
 - `--source`/`-s` dynamic values for `blz search` (also supports `--alias` for backward compatibility)
-- Positional alias completion for `blz get`, `blz refresh`, `blz remove`, `blz toc`, and `blz anchor list|get`
+- Positional alias completion for `blz get`, `blz refresh` (and legacy `blz update`), `blz remove`, `blz diff`, `blz toc`, and `blz anchor list|get`
 - Anchor value completion for `blz anchor get <alias> <anchor>`
 
 It reads from `blz list --json` and merges canonical + metadata aliases. Falls back to the static `_blz` for everything else.
@@ -218,7 +145,7 @@ It reads from `blz list --json` and merges canonical + metadata aliases. Falls b
 ```zsh
 blz <TAB>                # Shows commands with descriptions
 blz search --<TAB>       # Shows options
-blz search <TAB>         # Complete aliases
+blz search <TAB>         # Complete aliases (with dynamic helper)
 ```
 
 ### Configuration
@@ -358,7 +285,7 @@ blz <TAB>
   search      Search across cached docs
   get         Get exact lines from a source
   list        List all cached sources
-  update      Update sources
+  refresh     Update sources
 ```
 
 ### Customization
@@ -427,7 +354,7 @@ source /path/to/blz/scripts/blz-dynamic-completions.fish
 Adds:
 
 - `--source`/`-s` dynamic values for `blz search` (also supports `--alias` for backward compatibility)
-- Positional alias completion for `blz get`, `blz refresh`, `blz remove`, `blz diff`, `blz toc`
+- Positional alias completion for `blz get`, `blz refresh` (and legacy `blz update`), `blz remove`, `blz diff`, `blz toc`
 - `blz anchor list <alias>` alias completion
 - `blz anchor get <alias> <anchor>` anchor completion (after alias is provided)
 
@@ -493,6 +420,84 @@ end
 3. **Pipes**: `blz list | grep anthropic`
 4. **JSON**: Parse with `jq` for scripting
 
+## Bash
+
+Standard completions for commands and options.
+
+### Installation
+
+#### Linux
+
+```bash
+# Most distros - standard location
+blz completions bash | sudo tee /usr/share/bash-completion/completions/blz
+
+# User-specific (no sudo required)
+mkdir -p ~/.local/share/bash-completion/completions
+blz completions bash > ~/.local/share/bash-completion/completions/blz
+
+# Reload
+source ~/.bashrc
+```
+
+#### macOS
+
+```bash
+# Install bash-completion first
+brew install bash-completion@2
+
+# Add to ~/.bash_profile
+echo '[[ -r "$(brew --prefix)/etc/profile.d/bash_completion.sh" ]] && . "$(brew --prefix)/etc/profile.d/bash_completion.sh"' >> ~/.bash_profile
+
+# Install completions
+blz completions bash > $(brew --prefix)/etc/bash_completion.d/blz
+
+# Reload
+source ~/.bash_profile
+```
+
+### Features
+
+- Command completion
+- Option/flag completion
+- Filename completion for paths
+
+### Usage
+
+```bash
+blz <TAB><TAB>           # List commands
+blz search --<TAB><TAB>  # List options
+blz add <TAB><TAB>       # Complete filenames
+```
+
+### Troubleshooting
+
+#### Completions not working
+
+```bash
+# Check bash-completion is loaded
+type _init_completion
+
+# If not found, ensure bash-completion is installed
+# Then source it manually
+source /usr/share/bash-completion/bash_completion
+```
+
+#### Old Bash version
+
+Bash 3.x (macOS default) has limited completion support. Consider:
+
+```bash
+# Install newer Bash
+brew install bash
+
+# Add to /etc/shells
+echo $(brew --prefix)/bin/bash | sudo tee -a /etc/shells
+
+# Change default shell
+chsh -s $(brew --prefix)/bin/bash
+```
+
 ## PowerShell
 
 Setup guide for PowerShell completions on Windows, macOS, and Linux.
@@ -502,15 +507,17 @@ Setup guide for PowerShell completions on Windows, macOS, and Linux.
 #### Windows PowerShell / PowerShell Core
 
 ```powershell
-# Generate completions (static)
+# Generate completions for the current session
 blz completions powershell | Out-String | Invoke-Expression
 
-# To make permanent, add to profile
-blz completions powershell >> $PROFILE
-
-# Or create/edit profile manually
-notepad $PROFILE
-# Add the output of: blz completions powershell
+# To make permanent, save to a file and load from your profile
+$profileDir = Split-Path -Parent $PROFILE
+$completionFile = Join-Path $profileDir "blz-completions.ps1"
+blz completions powershell > $completionFile
+if (-not (Select-String -Path $PROFILE -Pattern $completionFile -Quiet)) {
+    Add-Content $PROFILE "if (Test-Path `"$completionFile`") { . `"$completionFile`" }"
+}
+. $PROFILE
 ```
 
 #### Check Profile Location
@@ -532,7 +539,7 @@ if (!(Test-Path $PROFILE)) {
 
 - Command completion
 - Parameter completion
-- Dynamic argument completion
+- Dynamic alias/anchor completion (with helper script)
 
 ### Usage
 
@@ -602,7 +609,7 @@ Add to Windows Terminal settings.json:
 
 # Use same installation steps as above
 pwsh
-blz completions powershell >> $PROFILE
+# Then run the same completion setup commands as above
 ```
 
 ### Dynamic Alias Completion
@@ -617,7 +624,7 @@ For live alias suggestions (canonical + metadata aliases) when typing `blz` comm
 This adds:
 
 - `--source`/`-s` dynamic values for `blz search` (also supports `--alias` for backward compatibility)
-- Positional alias completion for `blz get`, `blz refresh`, `blz remove`, `blz toc`, and `blz anchor list|get`
+- Positional alias completion for `blz get`, `blz refresh` (and legacy `blz update`), `blz remove`, `blz diff`, `blz toc`, and `blz anchor list|get`
 - Anchor value completion for `blz anchor get <alias> <anchor>`
 
 It reads from `blz list --json` and merges canonical + metadata aliases.
@@ -916,7 +923,7 @@ This script:
 - Detects installed shells
 - Generates completions for each
 - Installs in the right location
-- Works on macOS and Linux
+- Works on macOS and Linux (and PowerShell if `pwsh` is available)
 
 ### Manual Update
 
@@ -927,6 +934,15 @@ When you update the `blz` binary:
 blz completions fish > ~/.config/fish/completions/blz.fish
 blz completions bash > ~/.local/share/bash-completion/completions/blz
 blz completions zsh > ~/.zsh/completions/_blz
+blz completions elvish > ~/.elvish/lib/blz.elv
+```
+
+PowerShell:
+
+```powershell
+$profileDir = Split-Path -Parent $PROFILE
+$completionFile = Join-Path $profileDir "blz-completions.ps1"
+blz completions powershell > $completionFile
 ```
 
 ## Troubleshooting
@@ -1059,9 +1075,9 @@ done
 
 To improve completions:
 
-1. Edit `crates/blz-cli/src/main.rs`
-2. Update the `Commands` enum with better descriptions
+1. Edit `crates/blz-cli/src/cli.rs` (static completions + command descriptions)
+2. Update helper scripts in `scripts/` for dynamic completions
 3. Rebuild: `cargo build --release`
-4. Test: `blz completions <shell>`
+4. Test: `blz completions <shell>` and `source scripts/blz-dynamic-completions.<shell>`
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for more details.

--- a/scripts/blz-dynamic-completions.fish
+++ b/scripts/blz-dynamic-completions.fish
@@ -6,7 +6,7 @@
 # Complete aliases for commands that need them
 function __fish_blz_complete_aliases
     # Get sources from blz list --format json and print canonical + metadata aliases
-    blz list --format json 2>/dev/null | python3 -c "
+    blz list --json 2>/dev/null | python3 -c "
 import json, sys
 try:
     data = json.load(sys.stdin)
@@ -36,7 +36,7 @@ function __fish_blz_complete_anchors_for_alias
     if test -z "$alias"
         return
     end
-    blz toc $alias --format json 2>/dev/null | python3 -c "
+    blz toc $alias --json 2>/dev/null | python3 -c "
 import json, sys
 try:
     data = json.load(sys.stdin)
@@ -80,6 +80,7 @@ complete -c blz -n "__fish_seen_subcommand_from search" -l alias -xa "(__fish_bl
 complete -c blz -n "__fish_seen_subcommand_from get" -xa "(__fish_blz_complete_aliases)"
 
 # Complete for update command
+complete -c blz -n "__fish_seen_subcommand_from refresh" -xa "(__fish_blz_complete_aliases)"
 complete -c blz -n "__fish_seen_subcommand_from update" -xa "(__fish_blz_complete_aliases)"
 
 # Complete for diff command

--- a/scripts/blz-dynamic-completions.ps1
+++ b/scripts/blz-dynamic-completions.ps1
@@ -1,5 +1,4 @@
 # Dynamic completions for blz (PowerShell)
-%
 # Provides runtime completions for:
 # - Aliases: `search --alias/-s/--source`, positional for `get`, `update`, `remove`, `toc`, and `anchor list|get` (alias: `anchors`)
 # - Heading anchors: `anchor get <alias> <anchor>` values
@@ -9,7 +8,7 @@
 
 function Get-BlzAliases {
     try {
-        $json = blz list --format json 2>$null | ConvertFrom-Json
+        $json = blz list --json 2>$null | ConvertFrom-Json
     } catch {
         return @()
     }
@@ -37,7 +36,7 @@ function Get-BlzAnchors {
     param([string]$Alias)
     if (-not $Alias) { return @() }
     try {
-        $json = blz toc $Alias --format json 2>$null | ConvertFrom-Json
+        $json = blz toc $Alias --json 2>$null | ConvertFrom-Json
     } catch {
         return @()
     }
@@ -78,7 +77,7 @@ Register-ArgumentCompleter -CommandName blz -ScriptBlock {
     }
 
     # Positional alias for common subcommands
-    if (@('get','update','remove','toc','anchors') -contains $sub) {
+    if (@('get','refresh','update','remove','diff','toc','anchors') -contains $sub) {
         # tokens: 0=blz 1=sub 2=<alias>
         if ($tokens.Count -le 2) {
             foreach ($a in $aliases) {

--- a/scripts/blz-dynamic-completions.zsh
+++ b/scripts/blz-dynamic-completions.zsh
@@ -11,7 +11,7 @@
 
 # Print aliases (canonical + metadata) as newline-separated list using JSON output.
 __blz_aliases() {
-  blz list --format json 2>/dev/null | python3 - <<'PY' 2>/dev/null
+  blz list --json 2>/dev/null | python3 - <<'PY' 2>/dev/null
 import json, sys
 try:
   data = json.load(sys.stdin)
@@ -41,7 +41,7 @@ __blz_anchors_for_alias() {
   if [[ -z "$alias" ]]; then
     return
   fi
-  blz toc "$alias" --format json 2>/dev/null | python3 - <<'PY' 2>/dev/null
+  blz toc "$alias" --json 2>/dev/null | python3 - <<'PY' 2>/dev/null
 import json, sys
 try:
   data = json.load(sys.stdin)
@@ -77,7 +77,7 @@ _blz_dynamic() {
   # positional alias for common subcommands
   if (( ret )); then
     case $sub in
-      get|update|remove|toc|anchors)
+      get|refresh|update|remove|diff|toc|anchors)
         if (( CURRENT == 3 )); then
           local -a aliases
           aliases=(${(f)$(__blz_aliases)})

--- a/scripts/install-completions.sh
+++ b/scripts/install-completions.sh
@@ -39,8 +39,36 @@ elif [ -d "/usr/local/share/zsh/site-functions" ]; then
     echo "✅ Zsh completions installed (system-wide)"
 fi
 
+# Elvish
+if [ -d "$HOME/.elvish/lib" ]; then
+    "$BINARY_PATH" completions elvish > "$HOME/.elvish/lib/$BINARY.elv"
+    echo "✅ Elvish completions installed"
+fi
+
+# PowerShell (pwsh)
+if command -v pwsh >/dev/null 2>&1; then
+    PROFILE_PATH="$(pwsh -NoProfile -Command '$PROFILE' 2>/dev/null || true)"
+    PROFILE_PATH="$(printf '%s' "$PROFILE_PATH" | tr -d '\r')"
+    if [ -n "$PROFILE_PATH" ]; then
+        PROFILE_DIR="$(dirname "$PROFILE_PATH")"
+        COMPLETIONS_FILE="$PROFILE_DIR/${BINARY}-completions.ps1"
+        mkdir -p "$PROFILE_DIR"
+        "$BINARY_PATH" completions powershell > "$COMPLETIONS_FILE"
+        if [ ! -f "$PROFILE_PATH" ] || ! grep -Fq "$COMPLETIONS_FILE" "$PROFILE_PATH"; then
+            {
+                echo ""
+                echo "# Load ${BINARY} completions"
+                echo "if (Test-Path \"$COMPLETIONS_FILE\") { . \"$COMPLETIONS_FILE\" }"
+            } >> "$PROFILE_PATH"
+        fi
+        echo "✅ PowerShell completions installed"
+    fi
+fi
+
 echo ""
 echo "Completions installed! Reload your shell or run:"
 echo "  Fish: source ~/.config/fish/config.fish"
 echo "  Bash: source ~/.bashrc"
 echo "  Zsh:  exec zsh"
+echo "  Elvish: exec elvish"
+echo "  PowerShell: . \$PROFILE"


### PR DESCRIPTION
## Summary
- align dynamic completion helpers across zsh/fish/pwsh for refresh/diff + --json
- extend install-completions.sh for elvish + powershell profile loading
- refresh shell integration docs + completions prompt with accurate setup steps

## Testing
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PowerShell and Elvish shell completion support.
  * Added `refresh` and `diff` subcommand completions across shells.
* **Documentation**
  * Expanded shell integration guide with explicit Bash, PowerShell, and Elvish setup instructions.
  * Updated terminology: "update" → "refresh" in completion workflows.
* **Refactor**
  * Standardized CLI flag format from `--format json` to `--json` in completion scripts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->