### PR TITLE
fix(ci): resolve clippy and release-please token

### DIFF
--- a/.github/workflows/release-please-canary.yml
+++ b/.github/workflows/release-please-canary.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Run release-please (canary)
         uses: googleapis/release-please-action@v4
         with:
-          # Use a PAT so tag creation triggers publish workflows.
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # Prefer PAT so tag creation triggers publish workflows; fall back to GITHUB_TOKEN.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           config-file: .release-please-canary.json
           manifest-file: .release-please-manifest.canary.json
           target-branch: ${{ github.ref_name }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Run release-please
         uses: googleapis/release-please-action@v4
         with:
-          # Use a PAT so tag creation triggers publish workflows.
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # Prefer PAT so tag creation triggers publish workflows; fall back to GITHUB_TOKEN.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: ${{ github.ref_name }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3379,7 +3379,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
- "rustix 1.1.2",
+ "rustix 1.1.3",
  "windows-sys 0.60.2",
 ]
 

--- a/crates/blz-cli/tests/common/mod.rs
+++ b/crates/blz-cli/tests/common/mod.rs
@@ -23,7 +23,7 @@ fn data_dir() -> &'static Path {
 /// Ensures child processes are cleaned up even when the harness aborts.
 #[allow(dead_code)]
 pub fn blz_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("blz").expect("blz binary should build for tests");
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("blz"));
     cmd.timeout(CMD_TIMEOUT);
     if std::env::var("BLZ_PARENT_GUARD_TIMEOUT_SECS").is_err() {
         cmd.env("BLZ_PARENT_GUARD_TIMEOUT_SECS", DEFAULT_GUARD_TIMEOUT_SECS);

--- a/crates/blz-cli/tests/format_alias.rs
+++ b/crates/blz-cli/tests/format_alias.rs
@@ -5,9 +5,13 @@ use std::str;
 use anyhow::Result;
 use assert_cmd::Command;
 
+fn blz_cmd() -> Command {
+    Command::new(assert_cmd::cargo::cargo_bin!("blz"))
+}
+
 #[test]
 fn deprecated_output_alias_warns_and_matches_format() -> Result<()> {
-    let canonical_stdout = Command::cargo_bin("blz")?
+    let canonical_stdout = blz_cmd()
         .env("BLZ_DISABLE_GUARD", "1")
         .args(["completions", "--format", "json", "--list"])
         .assert()
@@ -17,7 +21,7 @@ fn deprecated_output_alias_warns_and_matches_format() -> Result<()> {
         .clone();
 
     for flag in ["--output", "-o"] {
-        let assertion = Command::cargo_bin("blz")?
+        let assertion = blz_cmd()
             .env("BLZ_DISABLE_GUARD", "1")
             .args(["completions", flag, "json", "--list"])
             .assert()
@@ -48,7 +52,7 @@ fn deprecated_output_alias_warns_and_matches_format() -> Result<()> {
 
 #[test]
 fn deprecated_output_respects_quiet_flag() -> Result<()> {
-    let assertion = Command::cargo_bin("blz")?
+    let assertion = blz_cmd()
         .env("BLZ_DISABLE_GUARD", "1")
         .args(["-q", "completions", "--output", "json", "--list"])
         .assert()

--- a/crates/blz-cli/tests/pipe_detection.rs
+++ b/crates/blz-cli/tests/pipe_detection.rs
@@ -3,7 +3,6 @@
 
 mod common;
 
-use assert_cmd::cargo::cargo_bin;
 use serde_json::Value;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -12,7 +11,7 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn blz_binary_path() -> PathBuf {
-    cargo_bin("blz")
+    assert_cmd::cargo::cargo_bin!("blz").to_path_buf()
 }
 
 fn command_with_env(bin: &Path, data_dir: &Path, config_dir: &Path) -> Command {

--- a/crates/blz-mcp/src/tools/find.rs
+++ b/crates/blz-mcp/src/tools/find.rs
@@ -219,7 +219,7 @@ pub struct TocEntrySummary {
     pub anchor: Option<String>,
     /// Nested entries (tree mode only)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub children: Option<Vec<TocEntrySummary>>,
+    pub children: Option<Vec<Self>>,
 }
 
 /// Truncate a string to the specified number of characters, appending ellipsis when shortened.


### PR DESCRIPTION
## Summary
- fix clippy use_self lint in mcp TocEntrySummary children type
- fall back to GITHUB_TOKEN when RELEASE_PLEASE_TOKEN is missing
- update blz-cli tests to use assert_cmd::cargo::cargo_bin! macro
- update Cargo.lock from dependency merges

## Testing
- cargo clippy --workspace --all-targets --all-features -- -D warnings -A missing_docs -A clippy::missing_errors_doc -A clippy::missing_panics_doc

Closes #389

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow authentication to prefer a PAT with a safe fallback to the built-in token.
* **Refactor**
  * Adjusted a public data structure’s nested children representation (may affect integrations).
* **Tests**
  * Unified and simplified test binary invocation and helper usage to improve test reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->