### PR TITLE
chore(ci): enable npm trusted publishing (BLZ-302)

### DIFF
--- a/.agents/logs/202601062110-checkpoint-trusted-publishing.md
+++ b/.agents/logs/202601062110-checkpoint-trusted-publishing.md
@@ -1,0 +1,64 @@
+---
+date: 2026-01-06 21:10 UTC
+branch: chore/ci/npm-trusted-publishing
+slug: checkpoint-trusted-publishing
+pr: BLZ-302
+agent: codex
+---
+
+# Checkpoint - enable npm trusted publishing
+
+## Summary
+
+Make npm publishing rely on GitHub OIDC when `NPM_TOKEN` is absent and require
+npm 11.5.1+ for trusted publishing.
+
+## Tasks
+<!-- Use CLOSES: #123 / BLZ-45 for completed issues -->
+<!-- Use ADDRESSES: #123 / BLZ-45 for partial work -->
+<!-- Use RELATED: #123 / BLZ-45 for related but not closing -->
+
+### Done
+
+- [x] ADDRESSES: BLZ-302 enable npm trusted publishing (OIDC) in publish workflow
+
+### In Progress
+
+- [ ] Create PR + submit stack once branch is created
+
+### Not Started
+
+- [ ] …
+
+## Changes
+<!-- Include files changed with brief descriptions -->
+
+- `.github/workflows/publish-npm.yml` - make `NPM_TOKEN` optional and ensure npm 11.5.1+
+
+## Decisions & Rationale
+<!-- Key technical decisions and why they were made -->
+
+- Keep token fallback while preferring OIDC; npm CLI uses OIDC before tokens.
+- Require npm 11.5.1+ per npm trusted publishing requirements.
+
+## Current State
+
+- **Branch Status**: clean after commit
+- **CI Status**: not run
+- **PR Stack**: pending submit
+- **Open Items**: none
+
+## Blockers
+<!-- What's preventing progress, if anything -->
+
+## Next Steps
+
+- Submit PR for trusted publishing tweak
+- Proceed to release-please 1.5.0 slice
+
+## Follow-ups
+<!-- Non-critical items discovered during work to circle back to -->
+
+## Context/Notes
+
+---

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,7 +18,7 @@ on:
         type: string
     secrets:
       npm-token:
-        required: true
+        required: false
   workflow_dispatch:
     inputs:
       tag:
@@ -57,9 +57,11 @@ jobs:
             DIST_TAG="$INPUT_DIST_TAG"
             VERSION="$INPUT_VERSION"
           fi
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "dist_tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+          {
+            echo "tag=$TAG"
+            echo "version=$VERSION"
+            echo "dist_tag=$DIST_TAG"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Checkout tag
         uses: actions/checkout@v4
@@ -72,6 +74,11 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
           scope: '@outfitter'
+
+      - name: Ensure npm 11.5.1+ for trusted publishing
+        run: |
+          npm install -g npm@^11.5.1
+          npm --version
 
       - name: Validate package version
         run: |


### PR DESCRIPTION
## Summary
- allow npm publish to use GitHub OIDC when NPM_TOKEN is absent
- require npm 11.5.1+ for trusted publishing support
- group workflow output writes to satisfy actionlint

## Testing
- not run (workflow-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm package publishing workflow to support GitHub OIDC for authentication, making NPM_TOKEN optional.
  * Enforced npm 11.5.1+ as a requirement for trusted publishing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->