### PR TITLE
chore(release): set release-please 1.5.0 (BLZ-303)

### DIFF
--- a/.agents/logs/202601062135-checkpoint-release-please-1-5-0.md
+++ b/.agents/logs/202601062135-checkpoint-release-please-1-5-0.md
@@ -1,0 +1,64 @@
+---
+date: 2026-01-06 21:35 UTC
+branch: chore/ci/npm-trusted-publishing
+slug: checkpoint-release-please-1-5-0
+pr: #392 / BLZ-303
+agent: codex
+---
+
+# Checkpoint - force release-please 1.5.0
+
+## Summary
+
+Set release-please to cut v1.5.0 and ensure `package.json` is versioned
+alongside Cargo workspace releases.
+
+## Tasks
+<!-- Use CLOSES: #123 / BLZ-45 for completed issues -->
+<!-- Use ADDRESSES: #123 / BLZ-45 for partial work -->
+<!-- Use RELATED: #123 / BLZ-45 for related but not closing -->
+
+### Done
+
+- [x] ADDRESSES: BLZ-303 set release-as 1.5.0 and include package.json
+
+### In Progress
+
+- [ ] Create PR + submit stack once branch is created
+
+### Not Started
+
+- [ ] …
+
+## Changes
+<!-- Include files changed with brief descriptions -->
+
+- `.release-please-config.json` - add release-as and package.json extra-file
+
+## Decisions & Rationale
+<!-- Key technical decisions and why they were made -->
+
+- Force v1.5.0 so release-please doesn't default to 1.4.1.
+- Track package.json version for npm publish validation.
+
+## Current State
+
+- **Branch Status**: clean after commit
+- **CI Status**: not run
+- **PR Stack**: stacked above trusted publishing branch (pending submit)
+- **Open Items**: none
+
+## Blockers
+<!-- What's preventing progress, if anything -->
+
+## Next Steps
+
+- Submit PR for release-please 1.5.0 override
+- Remove release-as in follow-up after release PR merges
+
+## Follow-ups
+<!-- Non-critical items discovered during work to circle back to -->
+
+## Context/Notes
+
+---

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -18,8 +18,10 @@
   "packages": {
     ".": {
       "package-name": "@outfitter/blz",
+      "release-as": "1.5.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
+        {"type": "json", "path": "package.json", "jsonpath": "$.version"},
         {"type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.package.version"},
         {"type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['blz-core'].version"},
         {"type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['blz-mcp'].version"}


### PR DESCRIPTION
## Summary
- force release-please to cut v1.5.0 for the next release
- include package.json in release-please extra-files for npm version sync

## Testing
- not run (config-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration for version 1.5.0.
  * Added package version tracking during the release process.

* **Documentation**
  * Added release checkpoint documentation for v1.5.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->