### PR TITLE
chore(release): align baseline for v1.5.0 (BLZ-308)

### DIFF
--- a/.agents/logs/202601071833-checkpoint-release-as-reset.md
+++ b/.agents/logs/202601071833-checkpoint-release-as-reset.md
@@ -1,0 +1,63 @@
+---
+date: 2026-01-07 18:33 UTC
+branch: chore/release/release-as-1-5-0
+slug: checkpoint-release-as-reset
+pr: BLZ-308
+agent: codex
+---
+
+# Checkpoint - reset baseline and release-as
+
+## Summary
+
+Align package.json back to the baseline release version and re-enable the
+release-as override so release-please can cut v1.5.0.
+
+## Tasks
+<!-- Use CLOSES: #123 / BLZ-45 for completed issues -->
+<!-- Use ADDRESSES: #123 / BLZ-45 for partial work -->
+<!-- Use RELATED: #123 / BLZ-45 for related but not closing -->
+
+### Done
+
+- [x] ADDRESSES: BLZ-308 reset package.json to 1.3.0 and re-add release-as 1.5.0
+
+### In Progress
+
+- [ ] Create branch + submit PR once commit is ready
+
+### Not Started
+
+- [ ] …
+
+## Changes
+<!-- Include files changed with brief descriptions -->
+
+- `package.json` - reset version to 1.3.0
+- `.release-please-config.json` - re-add release-as 1.5.0
+
+## Decisions & Rationale
+<!-- Key technical decisions and why they were made -->
+
+- release-please requires extra-files to match the last tagged release.
+
+## Current State
+
+- **Branch Status**: clean after commit
+- **CI Status**: not run
+- **PR Stack**: pending submit
+- **Open Items**: none
+
+## Blockers
+<!-- What's preventing progress, if anything -->
+
+## Next Steps
+
+- Submit PR for baseline alignment + release-as override
+
+## Follow-ups
+<!-- Non-critical items discovered during work to circle back to -->
+
+## Context/Notes
+
+---

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -18,6 +18,7 @@
   "packages": {
     ".": {
       "package-name": "@outfitter/blz",
+      "release-as": "1.5.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         {"type": "json", "path": "package.json", "jsonpath": "$.version"},

--- a/package.json
+++ b/package.json
@@ -57,5 +57,5 @@
     "prepack": "node npm/prepack.js"
   },
   "type": "module",
-  "version": "1.4.0"
+  "version": "1.3.0"
 }


### PR DESCRIPTION
## Summary
- reset package.json to the v1.3.0 baseline so release-please can run
- re-add release-as 1.5.0 to force the next release version

## Testing
- not run (version metadata only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration settings to version 1.5.0
  * Adjusted package version to 1.3.0
  * Added checkpoint documentation for release workflow management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->