### PR TITLE
fix(release): enable cargo-workspace plugin

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -4,6 +4,7 @@
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "draft": true,
+  "plugins": ["cargo-workspace"],
   "pull-request-title-pattern": "chore: release ${version}",
   "changelog-sections": [
     {"type": "feat", "section": "Features"},


### PR DESCRIPTION
## Summary
- enable the release-please cargo-workspace plugin for workspace-aware versioning
- avoids release-please failures when workspace members use version.workspace = true

## Testing
- not run (config-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration for improved Rust workspace support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->