### PR TITLE
fix(release): switch release-please to node strategy

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,10 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "rust",
+  "release-type": "node",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "draft": true,
-  "plugins": ["cargo-workspace"],
   "pull-request-title-pattern": "chore: release ${version}",
   "changelog-sections": [
     {"type": "feat", "section": "Features"},


### PR DESCRIPTION
## Summary
- use the node release strategy so package.json is the version source of truth
- keep Cargo workspace versions in sync via extra-files without cargo-workspace parsing

## Testing
- not run (config-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release and build configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->