### PR TITLE
fix(release): disable draft releases

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -3,7 +3,7 @@
   "release-type": "node",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
-  "draft": true,
+  "draft": false,
   "pull-request-title-pattern": "chore: release ${version}",
   "changelog-sections": [
     {"type": "feat", "section": "Features"},


### PR DESCRIPTION
## Summary
- publish GitHub releases instead of creating draft releases
- prevents release-please from re-opening a release PR when only drafts exist

## Testing
- not run (config-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal infrastructure updates with no user-facing changes. The release process automation has been updated to modify how future release pull requests are handled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->