### PR TITLE
chore(release): drop release-as override

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -18,7 +18,6 @@
   "packages": {
     ".": {
       "package-name": "@outfitter/blz",
-      "release-as": "1.5.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         {"type": "json", "path": "package.json", "jsonpath": "$.version"},


### PR DESCRIPTION
## Summary
- remove the temporary release-as pin now that v1.5.0 is published

## Testing
- not run (config-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed explicit release version pinning from configuration to enable automatic version management for future releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->