### PR TITLE
chore(release): sync Cargo.lock versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "blz-cli"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "blz-core"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "blz-mcp"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "blz-core",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "blz-registry-build"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
## Summary
- align Cargo.lock workspace package versions with 1.5.0

## Testing
- not run (lockfile update)