### PR TITLE
fix(release): auto-label homebrew tap PRs

### DIFF
--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -312,6 +312,7 @@ jobs:
           branch: bump-blz-${{ steps.resolve.outputs.version }}
           commit-message: "blz ${{ steps.resolve.outputs.version }}"
           title: "blz ${{ steps.resolve.outputs.version }}"
+          labels: pr-pull
           body: |
             Bump blz formula to ${{ steps.resolve.outputs.version }}.
             - arm64 sha256: ${{ steps.tar.outputs.sha_arm64 || steps.resolve.outputs.sha_arm64 }}


### PR DESCRIPTION
## Summary
- add the pr-pull label when creating Homebrew tap PRs
- enables automatic merge via the tap's pr-pull workflow

## Testing
- not run (workflow change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the automated homebrew release workflow to verify package integrity across additional platforms (x64 and Linux) alongside ARM64 support, improving release reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->