### PR TITLE
fix(ci): use macos-14 for darwin builds

### DIFF
--- a/.github/workflows/reusable-build-v2.yml
+++ b/.github/workflows/reusable-build-v2.yml
@@ -37,7 +37,7 @@ on:
 jobs:
   build:
     name: Build ${{ inputs.target }}
-    runs-on: ${{ inputs.target == 'windows-x64' && 'windows-latest' || inputs.target == 'linux-x64' && 'ubuntu-latest' || inputs.target == 'darwin-x64' && 'macos-13' || 'macos-14' }}
+    runs-on: ${{ inputs.target == 'windows-x64' && 'windows-latest' || inputs.target == 'linux-x64' && 'ubuntu-latest' || 'macos-14' }}
     outputs:
       artifact_name: ${{ steps.meta.outputs.artifact_name }}
       artifact_id: ${{ steps.upload.outputs['artifact-id'] }}
@@ -97,11 +97,11 @@ jobs:
           set -euo pipefail
           cd target/release
           if [[ "${{ inputs.target }}" == "windows-x64" ]]; then
-            7z a blz-${{ inputs.version }}-${{ inputs.target }}.zip ${{ steps.vars.outputs.binary_name }}
-            echo "ARCHIVE_PATH=target/release/blz-${{ inputs.version }}-${{ inputs.target }}.zip" >> $GITHUB_ENV
+            7z a "blz-${{ inputs.version }}-${{ inputs.target }}.zip" "${{ steps.vars.outputs.binary_name }}"
+            echo "ARCHIVE_PATH=target/release/blz-${{ inputs.version }}-${{ inputs.target }}.zip" >> "$GITHUB_ENV"
           else
-            tar czf blz-${{ inputs.version }}-${{ inputs.target }}.tar.gz ${{ steps.vars.outputs.binary_name }}
-            echo "ARCHIVE_PATH=target/release/blz-${{ inputs.version }}-${{ inputs.target }}.tar.gz" >> $GITHUB_ENV
+            tar czf "blz-${{ inputs.version }}-${{ inputs.target }}.tar.gz" "${{ steps.vars.outputs.binary_name }}"
+            echo "ARCHIVE_PATH=target/release/blz-${{ inputs.version }}-${{ inputs.target }}.tar.gz" >> "$GITHUB_ENV"
           fi
 
       - name: Set artifact metadata


### PR DESCRIPTION
## Summary
- run both darwin targets on macos-14 to avoid macos-13 runner cancellations
- add quotes in archive step to satisfy shellcheck

## Testing
- not run (workflow change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build system reliability by optimizing runner selection for macOS environments.
  * Enhanced file handling and path management to better support special characters and spaces in archive operations.
  * Strengthened environment variable configuration for more consistent cross-platform builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->