### PR TITLE
fix(mcp): default prompts capability fields

### DIFF
--- a/crates/blz-mcp/src/server.rs
+++ b/crates/blz-mcp/src/server.rs
@@ -73,7 +73,7 @@ impl ServerHandler for McpServer {
                 }),
                 prompts: Some(PromptsCapability {
                     list_changed: None,
-                    get: Some(true),
+                    ..Default::default()
                 }),
                 ..Default::default()
             },


### PR DESCRIPTION
## Summary
- Use `..Default::default()` when building `PromptsCapability` to stay compatible with rmcp schema changes
- Fixes release builds when the `get` field is absent or present in rmcp

## Testing
- `cargo check -p blz-mcp`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified server capabilities configuration by using default values for prompt operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->