### PR TITLE
fix(ci): build linux on ubuntu-22.04

### DIFF
--- a/.github/workflows/reusable-build-v2.yml
+++ b/.github/workflows/reusable-build-v2.yml
@@ -37,7 +37,7 @@ on:
 jobs:
   build:
     name: Build ${{ inputs.target }}
-    runs-on: ${{ inputs.target == 'windows-x64' && 'windows-latest' || inputs.target == 'linux-x64' && 'ubuntu-latest' || 'macos-14' }}
+    runs-on: ${{ inputs.target == 'windows-x64' && 'windows-latest' || inputs.target == 'linux-x64' && 'ubuntu-22.04' || 'macos-14' }}
     outputs:
       artifact_name: ${{ steps.meta.outputs.artifact_name }}
       artifact_id: ${{ steps.upload.outputs['artifact-id'] }}


### PR DESCRIPTION
## Summary
- build linux-x64 artifacts on ubuntu-22.04 so glibc stays compatible with Homebrew test-bot
- keep macOS and Windows runners unchanged

## Testing
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to enhance build environment consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->