### PR TITLE
chore(cli): clean up dead_code annotations after shape adoption (#BLZ-339)

### DIFF
--- a/crates/blz-cli/src/output/mod.rs
+++ b/crates/blz-cli/src/output/mod.rs
@@ -81,7 +81,7 @@ mod text;
 // All code using `crate::output::OutputFormat` continues to work
 pub use crate::args::OutputFormat;
 pub use formatter::{FormatParams, SearchResultFormatter};
-// TODO(BLZ-339): Remove allow once commands adopt these shapes.
+// Some shapes await command adoption (check, get/retrieve commands not yet migrated)
 #[allow(unused_imports)]
 pub use shapes::{
     CheckOutput, CheckResult, GenericOutput, OutputShape, RetrieveOutput, RetrievedContent,

--- a/crates/blz-cli/src/output/shapes.rs
+++ b/crates/blz-cli/src/output/shapes.rs
@@ -1,5 +1,6 @@
-// TODO(BLZ-339): Remove dead_code allow once commands adopt these shapes.
+// Some shapes and methods await adoption by remaining commands (check, get/retrieve)
 #![allow(dead_code)]
+
 //! Shape-based output types for CLI commands.
 //!
 //! This module provides typed output shapes that commands can return,


### PR DESCRIPTION
## Summary

Final cleanup after shape-based output migration.

- Update `#![allow(dead_code)]` comments to reflect remaining unadopted shapes
- Fix `unwrap()` usage in test code to satisfy strict clippy (`expect()` instead)
- Shapes awaiting adoption: `CheckOutput`, `GenericOutput`, `RetrieveOutput`

## Changes

- `output/shapes.rs`: Updated dead_code annotation comments
- `output/mod.rs`: Updated unused_imports annotation comments  
- `output/render.rs`: Replaced `.unwrap()` with `.expect()` in test

## Notes

The remaining shapes (`CheckOutput`, `RetrieveOutput`, `GenericOutput`) will be adopted when their corresponding commands (`check`, `get`) are migrated in future work.

## Test Plan

- [x] All tests pass
- [x] Strict clippy passes
- [x] No new warnings introduced

→ In-collaboration-with: [Claude Code](https://claude.com/claude-code)